### PR TITLE
Added support for Warn & Monitor policy modes

### DIFF
--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '0.0.99'
+__version__ = '1.0.0'

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -637,29 +637,15 @@ class Core:
             if alert_key not in head_scan_alerts:
                 new_alerts = new_scan_alerts[alert_key]
                 for alert in new_alerts:
-                    if Core.is_error(alert):
+                    if alert.error or alert.warn:
                         alerts.append(alert)
             else:
                 new_alerts = new_scan_alerts[alert_key]
                 head_alerts = head_scan_alerts[alert_key]
                 for alert in new_alerts:
-                    if alert not in head_alerts and Core.is_error(alert):
+                    if alert not in head_alerts and (alert.error or alert.warn):
                         alerts.append(alert)
         return alerts
-
-    @staticmethod
-    def is_error(alert: Alert):
-        """
-        Compare the current alert against the Security Policy to determine if it should be included. Can be overridden
-        with all_new_alerts Global setting if desired to return all alerts and not just the error category from the
-        security policy.
-        :param alert:
-        :return:
-        """
-        if all_new_alerts or (alert.type in security_policy and security_policy[alert.type]['action'] == "error"):
-            return True
-        else:
-            return False
 
     @staticmethod
     def create_issue_alerts(package: Package, alerts: dict, packages: dict) -> dict:
@@ -704,6 +690,9 @@ class Core:
                 purl=package.purl,
                 url=package.url
             )
+            if alert.type in security_policy:
+                action = security_policy[alert.type]['action']
+                setattr(issue_alert, action, True)
             if issue_alert.key not in alerts:
                 alerts[issue_alert.key] = [issue_alert]
             else:

--- a/socketsecurity/core/classes.py
+++ b/socketsecurity/core/classes.py
@@ -140,7 +140,10 @@ class Issue:
     pkg_id: str
     props: dict
     key: str
-    is_error: bool
+    error: bool
+    warn: bool
+    ignore: bool
+    monitor: bool
     description: str
     title: str
     emoji: str
@@ -162,6 +165,14 @@ class Issue:
             self.introduced_by = []
         if not hasattr(self, "manifests"):
             self.manifests = ""
+        if not hasattr(self, "error"):
+            self.error = False
+        if not hasattr(self, "warn"):
+            self.warn = False
+        if not hasattr(self, "monitor"):
+            self.monitor = False
+        if not hasattr(self, "ignore"):
+            self.ignore = False
 
     def __str__(self):
         return json.dumps(self.__dict__)


### PR DESCRIPTION
- Adds support for Security Policy Modes Block & Warn
   **Note:**  The Python CLI does not currently support individually triaged alerts
- Comments have been updated to have a new column in Github and Gitlab Comments with the new version to indicate Block/Warn
- The console output will include the CI Status of Block/Warn as well
- New option `--ignore-commit-files` to look for all manifest files whether or not there is one in the last commit detected
- Updated docker containers of `socketdev/cli:1.0.0` and `socketdev/cli:latest` have been pushed

![image](https://github.com/user-attachments/assets/c2d4a9e0-ab51-4492-b381-0066cfdaf8e6)
![image](https://github.com/user-attachments/assets/ad47ff66-0436-4b0b-8d92-9ae967211c5e)
