### PR TITLE
comparing file paths on manifest files to dedupe

### DIFF
--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '1.0.38'
+__version__ = '1.0.39'


### PR DESCRIPTION
Our case-insensitive file search led to us sending multiple copies of manifest files when we created a full scan. Now we are tracking seen file paths, so we only send one copy of each unique manifest