### PR TITLE
Updated workflows for buildx support

### DIFF
--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -27,6 +27,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build & Push Stable Docker
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -140,6 +140,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build & Push Docker Preview
         if: steps.verify_package.outputs.success == 'true'
         uses: docker/build-push-action@v5
@@ -147,7 +153,9 @@ jobs:
           VERSION: ${{ env.VERSION }}
         with:
           push: true
-          tags: socketdev/cli:pr-${{ github.event.pull_request.number }}
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            socketdev/cli:pr-${{ github.event.pull_request.number }}
           build-args: |
             CLI_VERSION=${{ env.VERSION }}
             PIP_INDEX_URL=https://test.pypi.org/simple

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Verify package is installable
         id: verify_package
         env:

--- a/scripts/build_container.sh
+++ b/scripts/build_container.sh
@@ -26,8 +26,8 @@ if [ $ENABLE_PYPI_BUILD = "pypi-build=test" ]; then
   python -m build --wheel --sdist
   twine upload --repository testpypi dist/*$VERSION*
   sleep 120
-  docker build --no-cache --build-arg CLI_VERSION=$VERSION --platform linux/amd64,linux/arm64 -t socketdev/cli:$VERSION . \
-    && docker build --no-cache --build-arg CLI_VERSION=$VERSION --platform linux/amd64,linux/arm64 -t socketdev/cli:latest . \
+  docker build --no-cache --build-arg CLI_VERSION=$VERSION --platform linux/amd64,linux/arm64 -t socketdev/cli:$VERSION-test . \
+    && docker build --no-cache --build-arg CLI_VERSION=$VERSION --platform linux/amd64,linux/arm64 -t socketdev/cli:test . \
     && docker push socketdev/cli:$VERSION-test \
     && docker push socketdev/cli:test
 fi


### PR DESCRIPTION
After a bit of digging, it turns out that we do need to specify the platforms so that arm64 hosts (like apple silicon macbooks) can run the resulting docker image. So instead of removing the platforms, I added the requisite workflow steps to get buildx set up.