### PR TITLE
added CLI_VERSION build-arg to build docker step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,3 +103,5 @@ jobs:
           tags: |
             socketdev/cli:latest
             socketdev/cli:${{ env.VERSION }}
+          build-args: |
+            CLI_VERSION=${{ env.VERSION }}


### PR DESCRIPTION
We were missing the CLI_VERSION build-arg in the release workflow's docker build step.

I didn't increment the version number to indicate that nothing in the CLI itself changed