### PR TITLE
lowered required python version to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "socketsecurity"
 dynamic = ["version"]
-requires-python = ">= 3.11"
+requires-python = ">= 3.9"
 dependencies = [
     'requests',
     'mdutils',

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.0.2'
+__version__ = '2.0.3'


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->
Pyproject specified too high of a minimum python version (3.11)

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->
This was originally driven by the sdk's typing improvements, and when the sdk used a polyfill library to lower this requirement, the change wasn't made in the CLI.

<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
