### PR TITLE
Now using supported files SDK endpoint for file globs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     'GitPython',
     'packaging',
     'python-dotenv',
-    'socket-sdk-python>=2.0.8'
+    'socket-sdk-python>=2.0.9'
 ]
 readme = "README.md"
 description = "Socket Security CLI for CI/CD"

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.0.10'
+__version__ = '2.0.11'

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -177,7 +177,7 @@ class Core:
         Gets supported file patterns from the Socket API.
 
         Returns:
-            Dictionary of supported file patterns
+            Dictionary of supported file patterns with 'general' key removed
         """
         response = self.sdk.report.supported()
         if not response:
@@ -185,6 +185,10 @@ class Core:
             # Import the old patterns as fallback
             from .utils import socket_globs
             return socket_globs
+
+        # Remove the 'general' key if it exists
+        if 'general' in response:
+            response.pop('general')
 
         # The response is already in the format we need
         return response


### PR DESCRIPTION
<!-- Description: Briefly describe the code improvement you're making. This could include things like lint fixes, adding Instead of using our static glob dict to search for files, we're now using the supported files SDK method.


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-improvement -->
