### PR TITLE
Eric/use types and logging

### DIFF
--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.0.11'
+__version__ = '2.0.12'

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -394,11 +394,10 @@ class Core:
             if not response.success:
                 log.error(f"Failed to get repository: {response.status}")
                 log.error(response.message)
-                # raise Exception(f"Failed to get repository info: {response.status}, message: {response.message}")
         except APIFailure:
             log.warning(f"Failed to get repository {repo_slug}, attempting to create it")
             try:
-                # Remove use_types=True since post() doesn't support it
+
                 create_response = self.sdk.repos.post(self.config.org_slug, name=repo_slug, default_branch=default_branch)
 
                 # Check if the response is empty (failure) or has content (success)
@@ -406,11 +405,9 @@ class Core:
                     log.error("Failed to create repository: empty response")
                     raise Exception("Failed to create repository: empty response")
                 else:
-                    # If we got here, create_response is a dictionary with the repository data
-                    return create_response  # This is already the repository data
+                    return create_response
 
             except APIFailure as e:
-                # Handle API failures from the post request
                 log.error(f"API failure while creating repository: {e}")
                 sys.exit(2) # Exit here with code 2. Code 1 indicates a successfully-detected security issue.
 

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -397,7 +397,7 @@ class Core:
                 # raise Exception(f"Failed to get repository info: {response.status}, message: {response.message}")
         except APIFailure:
             log.warning(f"Failed to get repository {repo_slug}, attempting to create it")
-            create_response = self.sdk.repos.post(self.config.org_slug, name=repo_slug, default_branch=default_branch)
+            create_response = self.sdk.repos.post(self.config.org_slug, name=repo_slug, default_branch=default_branch, use_types=True)
             if not create_response.success:
                 log.error(f"Failed to create repository: {create_response.status}")
                 log.error(create_response.message)

--- a/socketsecurity/core/logging.py
+++ b/socketsecurity/core/logging.py
@@ -1,5 +1,6 @@
 import logging
 
+
 def initialize_logging(
     level: int = logging.INFO,
     format: str = "%(asctime)s: %(message)s",
@@ -23,10 +24,24 @@ def initialize_logging(
     cli_logger = logging.getLogger(cli_logger_name)
     cli_logger.setLevel(level)
 
+    # Explicitly set urllib3 logger to WARNING to prevent debug messages
+    # when not in debug mode
+    urllib3_logger = logging.getLogger("urllib3")
+    urllib3_logger.setLevel(logging.WARNING)
+
+    # Also set git logger to WARNING
+    git_logger = logging.getLogger("git")
+    git_logger.setLevel(logging.WARNING)
+
     return socket_logger, cli_logger
 
-def set_debug_mode(enable: bool = True) -> None:
+def set_debug_mode(enable: bool = False) -> None:
     """Toggle debug logging across all loggers"""
     level = logging.DEBUG if enable else logging.INFO
     logging.getLogger("socketdev").setLevel(level)
     logging.getLogger("socketcli").setLevel(level)
+
+    # Also update urllib3 and git loggers when debug mode changes
+    urllib3_level = logging.DEBUG if enable else logging.WARNING
+    logging.getLogger("urllib3").setLevel(urllib3_level)
+    logging.getLogger("git").setLevel(urllib3_level)

--- a/socketsecurity/core/logging.py
+++ b/socketsecurity/core/logging.py
@@ -24,14 +24,6 @@ def initialize_logging(
     cli_logger = logging.getLogger(cli_logger_name)
     cli_logger.setLevel(level)
 
-    # Explicitly set urllib3 logger to WARNING to prevent debug messages
-    # when not in debug mode
-    urllib3_logger = logging.getLogger("urllib3")
-    urllib3_logger.setLevel(logging.WARNING)
-
-    # Also set git logger to WARNING
-    git_logger = logging.getLogger("git")
-    git_logger.setLevel(logging.WARNING)
 
     return socket_logger, cli_logger
 
@@ -40,8 +32,3 @@ def set_debug_mode(enable: bool = False) -> None:
     level = logging.DEBUG if enable else logging.INFO
     logging.getLogger("socketdev").setLevel(level)
     logging.getLogger("socketcli").setLevel(level)
-
-    # Also update urllib3 and git loggers when debug mode changes
-    urllib3_level = logging.DEBUG if enable else logging.WARNING
-    logging.getLogger("urllib3").setLevel(urllib3_level)
-    logging.getLogger("git").setLevel(urllib3_level)


### PR DESCRIPTION
- Fixes the debug logging (don't know the root cause yet, but this solves it)
- Correctly handles success and failure of create repo SDK call if there isn't an existing repo

We **thought** we need to add `use_types=True`, but there are no types for the post method in the SDK. 

The actual problem was that the SDK's repos.post method has the following code:

```python
    def post(self, org_slug: str, **kwargs) -> dict:
        params = {}
        if kwargs:
            for key, val in kwargs.items():
                params[key] = val
        if len(params) == 0:
            return {}

        path = "orgs/" + org_slug + "/repos"
        payload = json.dumps(params)
        response = self.api.do_request(path=path, method="POST", payload=payload)

        if response.status_code == 201:
            return response.json()

        error_message = response.json().get("error", {}).get("message", "Unknown error")
        log.error(f"Error creating repository: {response.status_code}, message: {error_message}")
        return {}
```


So the fix was to check for success by checking if the response had content or not. 

I've also wrapped this create call in its own try/except, and if it fails we log it and exit with code 2. 

So now if both calls fail there won't be an "unexpected error while running the CLI"

======

Proof that the logging issue is gone:

with debug enabled:
```shell
$> socketcli --repo test-large-repo --branch "test-cli-v2-perf" --pr_number 12 --target_path ../test-large-repo --timeout 1200 --enable-debug --exclude-license-details --ignore-commit-files
DEBUG:socketcli:Debug logging enabled
DEBUG:socketcli:loaded socket_config
DEBUG:socketcli:loaded client
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.socket.dev:443
DEBUG:urllib3.connectionpool:https://api.socket.dev:443 "GET /v0/organizations HTTP/11" 200 None
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.socket.dev:443
DEBUG:urllib3.connectionpool:https://api.socket.dev:443 "GET /v0/orgs/socketdev-demo/settings/security-policy 
...
INFO:socketdev:Total time to create new full scan: 5.81
INFO:socketdev:No head scan found. New scan ID: 089908d7-c2c7-40b3-aa65-791e35942cb5
INFO:socketcli:No issues found
```

without debug:

```shell
$> socketcli --repo test-large-repo --branch "test-cli-v2-perf" --pr_number 12 --target_path ../test-large-repo --timeout 1200  --exclude-license-details --ignore-commit-files 

INFO:socketcli:API Mode
INFO:socketdev:Total time to create new full scan: 17.40
INFO:socketdev:No head scan found. New scan ID: 75f0f2d1-8f45-4d98-b199-5dc9ac11be3f
INFO:socketcli:No issues found

```