### PR TITLE
Added back BASE_API_URL for the Socket API base

### DIFF
--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.0.12'
+__version__ = '2.0.13'

--- a/socketsecurity/core/socket_config.py
+++ b/socketsecurity/core/socket_config.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict, Optional
 from urllib.parse import urlparse
+import os
 
 from socketsecurity.core.issues import AllIssues
 
@@ -8,7 +9,7 @@ from socketsecurity.core.issues import AllIssues
 @dataclass
 class SocketConfig:
     api_key: str
-    api_url: str = "https://api.socket.dev/v0"
+    api_url: str = os.getenv("BASE_API_URL", "https://api.socket.dev/v0")
     timeout: int = 1200
     allow_unverified_ssl: bool = False
     org_id: Optional[str] = None


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->
In the refactor of the code the BASE_API_URL for local testing. 


## Fix
<!-- Explain how your changes address the bug ⬇️ -->
Added back in the option to override this via an environment variable. 

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
N/A
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
