### PR TITLE
Doug/fix supported files

### DIFF
--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.0.13'
+__version__ = '2.0.14'

--- a/socketsecurity/config.py
+++ b/socketsecurity/config.py
@@ -55,7 +55,7 @@ class CliConfig:
             'pr_number': args.pr_number,
             'commit_message': commit_message,
             'default_branch': args.default_branch,
-            'target_path': args.target_path,
+            'target_path': os.path.expanduser(args.target_path),
             'scm': args.scm,
             'sbom_file': args.sbom_file,
             'commit_sha': args.commit_sha,

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -124,14 +124,6 @@ class Core:
             return {}
 
     @staticmethod
-    def to_case_insensitive_regex(pattern: str) -> str:
-        """
-        Converts a pattern to a case-insensitive regex (optional step).
-        If `pattern` is a glob pattern, this step should be removed.
-        """
-        return pattern  # Remove if unnecessary
-
-    @staticmethod
     def expand_brace_pattern(pattern: str) -> List[str]:
         """
         Expands brace expressions (e.g., {a,b,c}) into separate patterns.


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->
In moving to using the supported files endpoint to get the patterns for manifest files it broke the detection for some of the Manifest types due to being regex patterns and not glob patterns.

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->
Moving to Supported API and not accounting for patterns being regex and not glob


## Fix
Added functions to convert the regex patterns to globs.

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
- Important fix for detecting supported manifest files after moving to the supported files API endpoint
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
