### PR TITLE
Bumped version for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.0.33"
+version = "2.0.34"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.0.33'
+__version__ = '2.0.34'
 

--- a/socketsecurity/core/classes.py
+++ b/socketsecurity/core/classes.py
@@ -138,6 +138,13 @@ class Package(SocketArtifactLink):
         Returns:
             New Package instance
         """
+        purl = f"{data['type']}/"
+        namespace = data.get("namespace")
+        if namespace:
+            purl += f"{namespace}@"
+        purl += f"{data['name']}@{data['version']}"
+        base_url = "https://socket.dev"
+        url = f"{base_url}/{data['type']}/package/{namespace or ''}{data['name']}/overview/{data['version']}"
         return cls(
             id=data["id"],
             name=data["name"],
@@ -152,7 +159,10 @@ class Package(SocketArtifactLink):
             direct=data.get("direct", False),
             manifestFiles=data.get("manifestFiles", []),
             dependencies=data.get("dependencies"),
-            artifact=data.get("artifact")
+            artifact=data.get("artifact"),
+            purl=purl,
+            url=url,
+            namespace=namespace
         )
 
     @classmethod


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->
Issue with creating a new repo and handling there being no full scan causing an error. Also, when there was no head full scan there were no results.
## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->
When switching to the new endpoint some of the logic for when not diffing were removed which caused a gap in detection.


## Fix
<!-- Explain how your changes address the bug ⬇️ -->
1. When creating a repo because it doesn't exist yet in the retry adding in logic to handle the no head scan
2. removed a hardcoded variable that was forcing diff and then bypassing diff when no head full scan
3. Added the logic back in for treating the results from the full scan as the diffed results
4. Fixed the package creation from SBOM Artifact to include purl and package url

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
- Fixed CLI logic to correctly handle when there is no head full scan or the repo does not exist before the full scan is ran
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
