### PR TITLE
Updated version for build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.0.34"
+version = "2.0.35"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.0.34'
+__version__ = '2.0.35'
 

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -90,6 +90,8 @@ class Core:
             log.debug(f"Failed to get SBOM data for full-scan {full_scan_id}")
             log.debug(response.message)
             return {}
+        if not hasattr(response, "artifacts") or not response.artifacts:
+            return artifacts
         for artifact_id in response.artifacts:
             artifacts.append(response.artifacts[artifact_id])
         return artifacts


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->
CLI could have a failure if the Full Scan was empty
## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->
get_sbom_data would try to reference response.artifacts which didn't exist if the full scan was empty


## Fix
<!-- Explain how your changes address the bug ⬇️ -->
Added a check for the class attribute and if not present just return the empty result

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
- Fixed an issue that could lead to the Python CLI failing if the full scan had no results
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
