### PR TITLE
Updated version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.0.35"
+version = "2.0.36"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.0.35'
+__version__ = '2.0.36'
 

--- a/socketsecurity/config.py
+++ b/socketsecurity/config.py
@@ -2,6 +2,7 @@ import argparse
 import os
 from dataclasses import asdict, dataclass
 from typing import List, Optional
+from socketdev import __version__
 
 from socketdev import INTEGRATION_TYPES, IntegrationType
 
@@ -35,6 +36,7 @@ class CliConfig:
     timeout: Optional[int] = 1200
     exclude_license_details: bool = False
     include_module_folders: bool = False
+    version: str = __version__
     @classmethod
     def from_args(cls, args_list: Optional[List[str]] = None) -> 'CliConfig':
         parser = create_argument_parser()
@@ -75,6 +77,7 @@ class CliConfig:
             'timeout': args.timeout,
             'exclude_license_details': args.exclude_license_details,
             'include_module_folders': args.include_module_folders,
+            'version': __version__
         }
 
         if args.owner:
@@ -358,6 +361,12 @@ def create_argument_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="Enabling including module folders like node_modules"
+    )
+
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f'%(prog)s {__version__}'
     )
 
     return parser


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->
When no top level ancestors the cli would fail

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->
assuming an attribute existed when it did not or was none


## Fix
<!-- Explain how your changes address the bug ⬇️ -->
Added a check for the attribute

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
- Fix for a case where an attribute of a package could be None and cause the cli to fail
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
