### PR TITLE
Updated version

### DIFF
--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.0.40'
+__version__ = '2.0.41'
 

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -801,7 +801,6 @@ class Core:
             alert = Alert(**alert_item)
             props = getattr(self.config.all_issues, alert.type, default_props)
             introduced_by = self.get_source_data(package, packages)
-
             issue_alert = Issue(
                 pkg_type=package.type,
                 pkg_name=package.name,

--- a/socketsecurity/core/messages.py
+++ b/socketsecurity/core/messages.py
@@ -3,6 +3,7 @@ import logging
 import re
 from pathlib import Path
 
+from docutils.nodes import title
 from mdutils import MdUtils
 from prettytable import PrettyTable
 
@@ -233,10 +234,21 @@ class Messages:
                 # Create a unique rule id and name by appending the manifest file.
                 unique_rule_id = f"{base_rule_id} ({mf})"
                 rule_name = f"Alert {base_rule_id} ({mf})"
-
-                short_desc = (f"{alert.props.get('note', '')}<br/><br/>Suggested Action:<br/>{alert.suggestion}"
+                props = {}
+                if hasattr(alert, 'props'):
+                    props = alert.props
+                suggestion = ''
+                if hasattr(alert, 'suggestion'):
+                    suggestion = alert.suggestion
+                alert_title = ''
+                if hasattr(alert, 'title'):
+                    alert_title = alert.title
+                description = ''
+                if hasattr(alert, 'description'):
+                    description = alert.description
+                short_desc = (f"{props.get('note', '')}<br/><br/>Suggested Action:<br/>{suggestion}"
                               f"<br/><a href=\"{socket_url}\">{socket_url}</a>")
-                full_desc = "{} - {}".format(alert.title, alert.description.replace('\r\n', '<br/>'))
+                full_desc = "{} - {}".format(alert_title, description.replace('\r\n', '<br/>'))
 
                 if unique_rule_id not in rules_map:
                     rules_map[unique_rule_id] = {


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->
In some cases when outputting the SARIF format certain alert attributed might not exist leading to:

````
AttributeError: 'NoneType' object has no attribute 'get'
````

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->
No checks to make sure the class attributes existed before calling for Alert


## Fix
<!-- Explain how your changes address the bug ⬇️ -->
Added explicit checks to make sure they did exist. Probably want to move this to the class at some point

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
- Fixed version for ensuring that the alert attributes exist when outputting to SARIF to prevent the CLI from erroring out unexpectedly
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
