### PR TITLE
Fixed slack import breaking bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.0.51"
+version = "2.0.52"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.0.51'
+__version__ = '2.0.52'

--- a/socketsecurity/plugins/slack.py
+++ b/socketsecurity/plugins/slack.py
@@ -1,6 +1,6 @@
 import logging
 import requests
-from config import CliConfig
+from socketsecurity.config import CliConfig
 from .base import Plugin
 from socketsecurity.core.classes import Diff
 from socketsecurity.core.messages import Messages


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->
in <module>
    from config import CliConfig
ModuleNotFoundError: No module named 'config'

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->
Relative path import works locally but not when deployed


## Fix
<!-- Explain how your changes address the bug ⬇️ -->

Corrected to have a full path versus relative

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
N/A
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
