### PR TITLE
Doug/add private flag for repo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.0.54"
+version = "2.0.55"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.0.52"
+version = "2.0.53"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.0.52'
+__version__ = '2.0.53'

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.0.54'
+__version__ = '2.0.55'

--- a/socketsecurity/config.py
+++ b/socketsecurity/config.py
@@ -150,7 +150,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
     )
     repo_group.add_argument(
         "--repo-is-public",
-        dest="default_branch",
+        dest="repo_is_public",
         action="store_true",
         help="If set it will flag a new repository creation as public. Defaults to false."
     )

--- a/socketsecurity/config.py
+++ b/socketsecurity/config.py
@@ -50,6 +50,7 @@ class CliConfig:
     timeout: Optional[int] = 1200
     exclude_license_details: bool = False
     include_module_folders: bool = False
+    repo_is_public: bool = False
     version: str = __version__
     jira_plugin: PluginConfig = field(default_factory=PluginConfig)
     slack_plugin: PluginConfig = field(default_factory=PluginConfig)
@@ -94,6 +95,7 @@ class CliConfig:
             'timeout': args.timeout,
             'exclude_license_details': args.exclude_license_details,
             'include_module_folders': args.include_module_folders,
+            'repo_is_public': args.repo_is_public,
             'version': __version__
         }
         config_args.update({
@@ -147,17 +149,10 @@ def create_argument_parser() -> argparse.ArgumentParser:
         required=False
     )
     repo_group.add_argument(
-        "--integration",
-        choices=INTEGRATION_TYPES,
-        metavar="<type>",
-        help="Integration type",
-        default="api"
-    )
-    repo_group.add_argument(
-        "--owner",
-        metavar="<name>",
-        help="Name of the integration owner, defaults to the socket organization slug",
-        required=False
+        "--repo-is-public",
+        dest="default_branch",
+        action="store_true",
+        help="If set it will flag a new repository creation as public. Defaults to false."
     )
     repo_group.add_argument(
         "--branch",
@@ -165,11 +160,20 @@ def create_argument_parser() -> argparse.ArgumentParser:
         help="Branch name",
         default=""
     )
-    repo_group.add_argument(
-        "--committers",
+
+    integration_group = parser.add_argument_group('Integration')
+    integration_group.add_argument(
+        "--integration",
+        choices=INTEGRATION_TYPES,
+        metavar="<type>",
+        help="Integration type of api, github, gitlab, azure, or bitbucket. Defaults to api",
+        default="api"
+    )
+    integration_group.add_argument(
+        "--owner",
         metavar="<name>",
-        help="Committer(s) to filter by",
-        nargs="*"
+        help="Name of the integration owner, defaults to the socket organization slug",
+        required=False
     )
 
     # Pull Request and Commit info
@@ -208,6 +212,12 @@ def create_argument_parser() -> argparse.ArgumentParser:
         "--commit_sha",
         dest="commit_sha",
         help=argparse.SUPPRESS
+    )
+    pr_group.add_argument(
+        "--committers",
+        metavar="<name>",
+        help="Committer for the commit (comma separated)",
+        nargs="*"
     )
 
     # Path and File options

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -439,7 +439,12 @@ class Core:
             log.warning(f"Failed to get repository {repo_slug}, attempting to create it")
             try:
 
-                create_response = self.sdk.repos.post(self.config.org_slug, name=repo_slug, default_branch=default_branch)
+                create_response = self.sdk.repos.post(
+                    self.config.org_slug,
+                    name=repo_slug,
+                    default_branch=default_branch,
+                    visibility=self.config.repo_visibility
+                )
 
                 # Check if the response is empty (failure) or has content (success)
                 if not create_response:

--- a/socketsecurity/core/socket_config.py
+++ b/socketsecurity/core/socket_config.py
@@ -26,6 +26,7 @@ class SocketConfig:
     full_scan_path: Optional[str] = None
     repository_path: Optional[str] = None
     security_policy: Dict = None
+    repo_visibility: Optional[str] = 'private'
     all_issues: Optional['AllIssues'] = None
     excluded_dirs: Set[str] = field(default_factory=lambda: default_exclude_dirs)
     version: str = __version__

--- a/socketsecurity/socketcli.py
+++ b/socketsecurity/socketcli.py
@@ -148,6 +148,8 @@ def main_code():
         log.debug("Found manifest files or forced scan, proceeding")
 
     org_slug = core.config.org_slug
+    if config.repo_is_public:
+        core.config.repo_visibility = "public"
     integration_type = config.integration_type
     integration_org_slug = config.integration_org_slug or org_slug
     try:

--- a/socketsecurity/socketcli.py
+++ b/socketsecurity/socketcli.py
@@ -150,6 +150,10 @@ def main_code():
     org_slug = core.config.org_slug
     integration_type = config.integration_type
     integration_org_slug = config.integration_org_slug or org_slug
+    try:
+        pr_number = int(config.pr_number)
+    except (ValueError, TypeError):
+        pr_number = 0
 
     params = FullScanParams(
         org_slug=org_slug,
@@ -159,7 +163,7 @@ def main_code():
         branch=config.branch,
         commit_message=config.commit_message,
         commit_hash=config.commit_sha,
-        pull_request=config.pr_number,
+        pull_request=pr_number,
         committers=config.committers,
         make_default_branch=config.default_branch,
         set_as_pending_head=True


### PR DESCRIPTION
<!-- Description: Briefly describe the new feature you're introducing ⬇️ -->
If the CLI needs to create a repo have an option to set public/private

## Why?
<!-- Explain the motivation behind this feature and its expected benefits ⬇️ -->
It was requested that if the CLI needed to create a new repo that the visibility could be chosen. This has been updated to support that.


## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog. -->

<!-- changelog ⬇️-->
- Added support to set whether a new repo created by the CLI is public or private
<!-- /changelog ⬆️ -->

<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-feature -->
