### PR TITLE
Added support for exlcuded ecosystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ If you don't want to provide the Socket API Token every time then you can use th
 | --api-token | False    |         | Socket Security API token (can also be set via SOCKET_SECURITY_API_KEY env var) |
 
 #### Repository
-| Parameter     | Required | Default | Description                                                             |
-|:--------------|:---------|:--------|:------------------------------------------------------------------------|
-| --repo        | False    |         | Repository name in owner/repo format                                    |
-| --integration | False    | api     | Integration type (api, github, gitlab)                                  |
-| --owner       | False    |         | Name of the integration owner, defaults to the socket organization slug |
-| --branch      | False    | ""      | Branch name                                                             |
-| --committers  | False    |         | Committer(s) to filter by                                               |
+| Parameter        | Required | Default | Description                                                             |
+|:-----------------|:---------|:--------|:------------------------------------------------------------------------|
+| --repo           | False    |         | Repository name in owner/repo format                                    |
+| --integration    | False    | api     | Integration type (api, github, gitlab)                                  |
+| --owner          | False    |         | Name of the integration owner, defaults to the socket organization slug |
+| --branch         | False    | ""      | Branch name                                                             |
+| --committers     | False    |         | Committer(s) to filter by                                               |
+| --repo-is-public | False    | False   | If set, flags a new repository creation as public. Defaults to false.   |
 
 #### Pull Request and Commit
 | Parameter        | Required | Default | Description         |
@@ -39,11 +40,12 @@ If you don't want to provide the Socket API Token every time then you can use th
 | --commit-sha     | False    | ""      | Commit SHA          |
 
 #### Path and File
-| Parameter     | Required | Default | Description                          |
-|:--------------|:---------|:--------|:-------------------------------------|
-| --target-path | False    | ./      | Target path for analysis             |
-| --sbom-file   | False    |         | SBOM file path                       |
-| --files       | False    | []      | Files to analyze (JSON array string) |
+| Parameter          | Required | Default | Description                                                                                                                                                                    |
+|:-------------------|:---------|:--------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --target-path      | False    | ./      | Target path for analysis                                                                                                                                                       |
+| --sbom-file        | False    |         | SBOM file path                                                                                                                                                                 |
+| --files            | False    | []      | Files to analyze (JSON array string)                                                                                                                                           |
+| --exclude-patterns | False    | []      | List of patterns to exclude from analysis (JSON array string). You can get supported files form the [Supported Files API](https://docs.socket.dev/reference/getsupportedfiles) |
 
 #### Branch and Scan Configuration
 | Parameter        | Required | Default | Description                                                 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.0.55"
+version = "2.0.56"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.0.55'
+__version__ = '2.0.56'

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -184,6 +184,8 @@ class Core:
             patterns = fallback_patterns
 
         for ecosystem in patterns:
+            if ecosystem in self.config.excluded_ecosystems:
+                continue
             ecosystem_patterns = patterns[ecosystem]
             for file_name in ecosystem_patterns:
                 original_pattern = ecosystem_patterns[file_name]["pattern"]

--- a/socketsecurity/core/socket_config.py
+++ b/socketsecurity/core/socket_config.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Dict, Optional
 from urllib.parse import urlparse
-from typing import Set
+from typing import Set, List
 import os
 
 from socketsecurity.core.issues import AllIssues
@@ -29,6 +29,7 @@ class SocketConfig:
     repo_visibility: Optional[str] = 'private'
     all_issues: Optional['AllIssues'] = None
     excluded_dirs: Set[str] = field(default_factory=lambda: default_exclude_dirs)
+    excluded_ecosystems: List[str] = field(default_factory=lambda: [])
     version: str = __version__
 
     def __post_init__(self):

--- a/socketsecurity/socketcli.py
+++ b/socketsecurity/socketcli.py
@@ -150,6 +150,8 @@ def main_code():
     org_slug = core.config.org_slug
     if config.repo_is_public:
         core.config.repo_visibility = "public"
+    if config.excluded_ecosystems and len(config.excluded_ecosystems) > 0:
+        core.config.excluded_ecosystems = config.excluded_ecosystems
     integration_type = config.integration_type
     integration_org_slug = config.integration_org_slug or org_slug
     try:


### PR DESCRIPTION
<!-- Description: Briefly describe the new feature you're introducing ⬇️ -->
Adding support to exclude ecosystems from scanning

## Why?
<!-- Explain the motivation behind this feature and its expected benefits ⬇️ -->
For customers where certain language results aren't desired it is not possible to disable ecosystems


## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog. -->

<!-- changelog ⬇️-->
- Added support to exclude Ecosystems from the Socket CLI Scans based on the Supported Files API Endpoint
<!-- /changelog ⬆️ -->

<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-feature -->
