### PR TITLE
Updated version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.2"
+version = "2.1.3"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [
@@ -16,7 +16,7 @@ dependencies = [
     'GitPython',
     'packaging',
     'python-dotenv',
-    'socket-sdk-python>=2.1.2,<3'
+    'socket-sdk-python>=2.1.5,<3'
 ]
 readme = "README.md"
 description = "Socket Security CLI for CI/CD"

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.2'
+__version__ = '2.1.3'

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -670,7 +670,7 @@ class Core:
         diff.report_url = report_url
 
         if head_full_scan_id is not None:
-            diff.diff_url = f"{base_socket}/{self.config.org_slug}/diff/{diff.id}/{head_full_scan_id}"
+            diff.diff_url = f"{base_socket}/{self.config.org_slug}/diff/{head_full_scan_id}/{diff.id}"
         else:
             diff.diff_url = diff.report_url
 


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->
Diff URL had head full scan ID and diff scan ID reversed
## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->
It was hard coded incorrectly


## Fix
<!-- Explain how your changes address the bug ⬇️ -->

Fixed the ordering in the URL Generation

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
- Minor fix to the Diff URL Generation for correctly showing the diff
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
