### PR TITLE
Fixed license generation using the purl endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.9"
+version = "2.1.10"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.9'
+__version__ = '2.1.10'

--- a/socketsecurity/core/classes.py
+++ b/socketsecurity/core/classes.py
@@ -132,6 +132,7 @@ class Package():
 
     # Artifact-specific fields
     licenseDetails: Optional[list] = None
+    licenseAttrib: Optional[List] = None
 
 
     @classmethod
@@ -469,14 +470,15 @@ class Diff:
     """
     
     new_packages: list[Purl]
-    new_capabilities: Dict[str, List[str]]
     removed_packages: list[Purl]
+    packages: dict[str, Package]
+    new_capabilities: Dict[str, List[str]]
     new_alerts: list[Issue]
     id: str
     sbom: str
-    packages: dict[str, Package]
     report_url: str
     diff_url: str
+    new_scan_id: str
 
     def __init__(self, **kwargs):
         if kwargs:

--- a/socketsecurity/socketcli.py
+++ b/socketsecurity/socketcli.py
@@ -7,6 +7,7 @@ from git import InvalidGitRepositoryError, NoSuchPathError
 from socketdev import socketdev
 from socketdev.fullscans import FullScanParams
 
+from core.exceptions import APIFailure
 from socketsecurity.config import CliConfig
 from socketsecurity.core import Core
 from socketsecurity.core.classes import Diff
@@ -260,22 +261,24 @@ def main_code():
         diff = core.create_new_diff(config.target_path, params, no_change=should_skip_scan)
         output_handler.handle_output(diff)
 
-    # Handle license generation
+        # Handle license generation
     if diff is not None and config.generate_license:
         all_packages = {}
-        for package_id in diff.packages:
-            package = diff.packages[package_id]
+        for purl in diff.packages:
+            package = diff.packages[purl]
             output = {
-                "id": package_id,
+                "id": package.id,
                 "name": package.name,
                 "version": package.version,
                 "ecosystem": package.type,
                 "direct": package.direct,
                 "url": package.url,
                 "license": package.license,
-                "license_text": package.license_text
+                "licenseDetails": package.licenseDetails,
+                "licenseAttrib": package.licenseAttrib,
+                "purl": package.purl,
             }
-            all_packages[package_id] = output
+            all_packages[package.id] = output
         license_file = f"{config.repo}"
         if config.branch:
             license_file += f"_{config.branch}"


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->

Python CLI was erroring out on generating license from both using the new diff endpoint and the license objects changing.

## Fix
<!-- Explain how your changes address the bug ⬇️ -->

Added in logic to use the batch purl endpoint to retrieve the license details.

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
- Fixed the CLI to work with generating the license attribution again. The `license_text` property has been replaced with `licenseDetails` and `licenseAttrib`
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
