### PR TITLE
manifestFiles could exist for direct but be none. fixed the check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.16"
+version = "2.1.17"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.16'
+__version__ = '2.1.17'

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -858,12 +858,11 @@ class Core:
         introduced_by = []
         if package.direct:
             manifests = ""
-            if not hasattr(package, "manifestFiles"):
+            if not hasattr(package, "manifestFiles") or package.manifestFiles is None:
                 return introduced_by
-            if hasattr(package, "manifestFiles"):
-                for manifest_data in package.manifestFiles:
-                    manifest_file = manifest_data.get("file")
-                    manifests += f"{manifest_file};"
+            for manifest_data in package.manifestFiles:
+                manifest_file = manifest_data.get("file")
+                manifests += f"{manifest_file};"
             manifests = manifests.rstrip(";")
             source = ("direct", manifests)
             introduced_by.append(source)


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->

Direct dependency `manifestFiles` could still be None breaking iteration

## Fix
<!-- Explain how your changes address the bug ⬇️ -->

Correctly returned if attribute didn't exist OR was None
## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
N/A
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
