### PR TITLE
Fix exit code from returning 5 on diff reports with no error alerts a…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.18"
+version = "2.1.19"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.18'
+__version__ = '2.1.19'

--- a/socketsecurity/output.py
+++ b/socketsecurity/output.py
@@ -52,10 +52,11 @@ class OutputHandler:
         
         if not self.report_pass(diff_report):
             return 1
-        
-        if len(diff_report.new_alerts) > 0:
-            # 5 means warning alerts but no blocking alerts
-            return 5
+
+        # if there are only warn alerts should be returning 0. This was not intended behavior
+        # if len(diff_report.new_alerts) > 0:
+        #     # 5 means warning alerts but no blocking alerts
+        #     return 5
         return 0    
 
     def output_console_comments(self, diff_report: Diff, sbom_file_name: Optional[str] = None) -> None:


### PR DESCRIPTION
…nd only warn

<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->

Logic was incorrectly added to have the CLI exit with error code 5 if there were only warn alerts in the diff report. This was not the intended behavior.

## Fix
<!-- Explain how your changes address the bug ⬇️ -->

Removed this incorrect logic

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
- Updated the CLI to return 0 for the exit code if the only alerts in the diff report are warn alerts instead of incorrectly returning 5

<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
