### PR TITLE
Added 'api' event type to Gitlab and added new option --license-file-…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ If you don't want to provide the Socket API Token every time then you can use th
 | --commit-sha     | False    | ""      | Commit SHA          |
 
 #### Path and File
-| Parameter             | Required | Default | Description                                                                                                                                                                    |
-|:----------------------|:---------|:--------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| --target-path         | False    | ./      | Target path for analysis                                                                                                                                                       |
-| --sbom-file           | False    |         | SBOM file path                                                                                                                                                                 |
-| --files               | False    | []      | Files to analyze (JSON array string)                                                                                                                                           |
-| --excluded-ecosystems | False    | []      | List of ecosystems to exclude from analysis (JSON array string). You can get supported files from the [Supported Files API](https://docs.socket.dev/reference/getsupportedfiles) |
+| Parameter             | Required | Default               | Description                                                                                                                                                                      |
+|:----------------------|:---------|:----------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --target-path         | False    | ./                    | Target path for analysis                                                                                                                                                         |
+| --sbom-file           | False    |                       | SBOM file path                                                                                                                                                                   |
+| --files               | False    | []                    | Files to analyze (JSON array string)                                                                                                                                             |
+| --excluded-ecosystems | False    | []                    | List of ecosystems to exclude from analysis (JSON array string). You can get supported files from the [Supported Files API](https://docs.socket.dev/reference/getsupportedfiles) |
+| --license-file-name   | False    | `license_output.json` | Name of the file to save the license details to if enabled                                                                                                                       |
 
 #### Branch and Scan Configuration
 | Parameter        | Required | Default | Description                                                 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.20"
+version = "2.1.21"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.19"
+version = "2.1.20"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -56,7 +56,7 @@ pytest-watch==4.2.0
     # via socketsecurity
 python-dotenv==1.0.1
     # via socketsecurity
-requests==2.32.3
+requests==2.32.4
     # via socket-sdk-python
     # via socketsecurity
 smmap==5.0.2
@@ -65,7 +65,7 @@ socket-sdk-python==2.0.15
     # via socketsecurity
 typing-extensions==4.12.2
     # via socket-sdk-python
-urllib3==2.3.0
+urllib3==2.5.0
     # via requests
 watchdog==6.0.0
     # via pytest-watch

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ pytest-watch==4.2.0
     # via socketsecurity
 python-dotenv==1.0.1
     # via socketsecurity
-requests==2.32.3
+requests==2.32.4
     # via socket-sdk-python
     # via socketsecurity
 smmap==5.0.2
@@ -63,7 +63,7 @@ socket-sdk-python==2.1.5
     # via socketsecurity
 typing-extensions==4.12.2
     # via socket-sdk-python
-urllib3==2.3.0
+urllib3==2.5.0
     # via requests
 watchdog==6.0.0
     # via pytest-watch

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.19'
+__version__ = '2.1.20'

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.20'
+__version__ = '2.1.21'

--- a/socketsecurity/config.py
+++ b/socketsecurity/config.py
@@ -56,6 +56,7 @@ class CliConfig:
     version: str = __version__
     jira_plugin: PluginConfig = field(default_factory=PluginConfig)
     slack_plugin: PluginConfig = field(default_factory=PluginConfig)
+    license_file_name: str = "license_output.json"
 
     @classmethod
     def from_args(cls, args_list: Optional[List[str]] = None) -> 'CliConfig':
@@ -99,6 +100,7 @@ class CliConfig:
             'include_module_folders': args.include_module_folders,
             'repo_is_public': args.repo_is_public,
             "excluded_ecosystems": args.excluded_ecosystems,
+            'license_file_name': args.license_file_name,
             'version': __version__
         }
         try:
@@ -252,6 +254,13 @@ def create_argument_parser() -> argparse.ArgumentParser:
         "--sbom_file",
         dest="sbom_file",
         help=argparse.SUPPRESS
+    )
+    path_group.add_argument(
+        "--license-file-name",
+        dest="license_file_name",
+        default="license_output.json",
+        metavar="<string>",
+        help="SBOM file path"
     )
     path_group.add_argument(
         "--files",

--- a/socketsecurity/core/scm/gitlab.py
+++ b/socketsecurity/core/scm/gitlab.py
@@ -71,7 +71,7 @@ class Gitlab:
 
     def check_event_type(self) -> str:
         pipeline_source = self.config.pipeline_source.lower()
-        if pipeline_source in ["web", 'merge_request_event', "push"]:
+        if pipeline_source in ["web", 'merge_request_event', "push", "api"]:
             if not self.config.mr_iid:
                 return "main"
             return "diff"

--- a/socketsecurity/socketcli.py
+++ b/socketsecurity/socketcli.py
@@ -277,11 +277,7 @@ def main_code():
                 "purl": package.purl,
             }
             all_packages[package.id] = output
-        license_file = f"{config.repo}"
-        if config.branch:
-            license_file += f"_{config.branch}"
-        license_file += ".json"
-        core.save_file(license_file, json.dumps(all_packages))
+        core.save_file(config.license_file_name, json.dumps(all_packages))
 
     sys.exit(output_handler.return_exit_code(diff))
 


### PR DESCRIPTION
…name that defaults to license_output.json instead of a dynamic name that could be a bad filename

<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->

The file name that was being generated from the repo and branch was not being serialized to a safe file name that could cause the code to error.

The `api` event type for gitlab wasn't supported which would cause the CLI to error.

## Fix
<!-- Explain how your changes address the bug ⬇️ -->

1. Added the api event type to the gitlab logic.
2. Added a new param `--license-file-name` to use for the license file and defaults to `license_output.json`

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
- Added support for the `api` event type for Gitlab
- Added a new parameter `--license-file-name` instead of trying to generate the file name from the repo and branch for a safer license file name. 
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
