### PR TITLE
Refactor file detection and scanning logic to fix commit file handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.21"
+version = "2.1.22"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.21'
+__version__ = '2.1.22'


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->

The files logic for detecting if there were changed manifest files had been broken over time. At this point it was completely decoupled and in most instances things didn't work correctly without `--ignore-commit-files`

## Fix
<!-- Explain how your changes address the bug ⬇️ -->

- Fix file argument parsing to handle list, string, and JSON formats more robustly
- Clarify git repository detection and file selection logic with better separation of concerns
- Add force_api_mode to handle cases where no supported manifest files are found
- Replace ambiguous should_skip_scan logic with clearer file detection flow
- Add create_full_scan_with_report_url method to Core for API-mode scanning
- Improve logging messages and remove unused code (get_all_scores method)
- Ensure consistent diff object initialization and ID handling
- Automatically enable disable_blocking when no supported files are detected

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
• Fixed file detection logic that was preventing proper scanning of changed manifest files
• Improved handling of different file input formats (list, string, JSON) for better reliability
• Enhanced automatic detection of git repository changes and manifest file filtering
• Fixed cases where scans would incorrectly skip when manifest files were present in commits
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
