### PR TITLE
fix: correct default branch detection and ensure consistent scanning …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.23"
+version = "2.1.24"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.23'
+__version__ = '2.1.24'

--- a/workflows/bitbucket-pipelines.yml
+++ b/workflows/bitbucket-pipelines.yml
@@ -1,0 +1,85 @@
+# Socket Security Bitbucket Pipelines
+# This pipeline runs Socket Security scans on every commit to any branch
+# The CLI automatically detects most information from the git repository
+
+image: python:3.12-slim
+
+definitions:
+  steps:
+    - step: &socket-scan
+        name: Socket Security Scan
+        caches:
+          - pip
+        script:
+          - pip install --upgrade pip
+          - pip install socketsecurity
+          # Run Socket CLI with minimal required parameters
+          # The CLI automatically detects:
+          # - Repository name from git
+          # - Branch name from git
+          # - Commit SHA from git
+          # - Commit message from git
+          # - Committer information from git
+          # - Default branch status from git repository
+          # - Changed files from git commit
+          - |
+            socketcli \
+              --target-path $BITBUCKET_CLONE_DIR \
+              --scm api \
+              --pr-number ${BITBUCKET_PR_ID:-0}
+        # Repository variables needed (set in Bitbucket repo settings)
+        # SOCKET_SECURITY_API_KEY: Your Socket Security API token
+
+pipelines:
+  # Run on all branches
+  branches:
+    '**':
+      - step: *socket-scan
+  
+  # Run on pull requests
+  pull-requests:
+    '**':
+      - step: *socket-scan
+
+# Optional: More efficient version that only runs when manifest files change
+# To use this instead, replace the pipelines section above with:
+#
+# pipelines:
+#   branches:
+#     '**':
+#       - step:
+#           <<: *socket-scan
+#           condition:
+#             changesets:
+#               includePaths:
+#                 - "package.json"
+#                 - "package-lock.json"
+#                 - "yarn.lock"
+#                 - "pnpm-lock.yaml"
+#                 - "requirements.txt"
+#                 - "Pipfile"
+#                 - "Pipfile.lock"
+#                 - "pyproject.toml"
+#                 - "poetry.lock"
+#                 - "go.mod"
+#                 - "go.sum"
+#                 - "Cargo.toml"
+#                 - "Cargo.lock"
+#                 - "composer.json"
+#                 - "composer.lock"
+#                 - "Gemfile"
+#                 - "Gemfile.lock"
+#                 - "**/*.csproj"
+#                 - "**/*.fsproj"
+#                 - "**/*.vbproj"
+#                 - "packages.config"
+#                 - "paket.dependencies"
+#                 - "project.json"
+#   
+#   pull-requests:
+#     '**':
+#       - step: *socket-scan
+
+# Note: Bitbucket Pipelines doesn't have built-in SCM integration like 
+# GitHub Actions or GitLab CI, so we use --scm api mode which provides
+# basic scanning without PR comment functionality.

--- a/workflows/github-actions.yml
+++ b/workflows/github-actions.yml
@@ -1,0 +1,67 @@
+# Socket Security GitHub Actions Workflow
+# This workflow runs Socket Security scans on every commit to any branch
+# It automatically detects git repository information and handles different event types
+
+name: socket-security-workflow
+run-name: Socket Security Github Action
+
+on:
+  push:
+    branches: ['**']  # Run on all branches, all commits
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+# Prevent concurrent runs for the same commit
+concurrency:
+  group: socket-scan-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  socket-security:
+    permissions:
+      issues: write
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # For PRs, fetch one additional commit for proper diff analysis
+          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+      
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      
+      - name: Install Socket CLI
+        run: pip install socketsecurity --upgrade
+      
+      - name: Run Socket Security Scan
+        env:
+          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Determine PR number based on event type
+          PR_NUMBER=0
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            PR_NUMBER=${{ github.event.pull_request.number }}
+          elif [ "${{ github.event_name }}" == "issue_comment" ]; then
+            PR_NUMBER=${{ github.event.issue.number }}
+          fi
+          
+          # Run Socket CLI with minimal required parameters
+          # The CLI automatically detects:
+          # - Repository name from git
+          # - Branch name from git
+          # - Commit SHA from git
+          # - Commit message from git
+          # - Committer information from git
+          # - Default branch status from git and GitHub environment
+          # - Changed files from git commit
+          socketcli \
+            --target-path $GITHUB_WORKSPACE \
+            --scm github \
+            --pr-number $PR_NUMBER

--- a/workflows/gitlab-ci.yml
+++ b/workflows/gitlab-ci.yml
@@ -1,0 +1,81 @@
+# Socket Security GitLab CI Pipeline
+# This pipeline runs Socket Security scans on every commit to any branch
+# The CLI automatically detects most information from the git repository
+
+stages:
+  - security-scan
+
+socket-security:
+  stage: security-scan
+  image: python:3.12-slim
+  
+  # Run on all branches and merge requests
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  
+  variables:
+    # These environment variables are automatically available in GitLab CI
+    # and are used by the Socket CLI's GitLab SCM integration
+    PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+  
+  cache:
+    paths:
+      - .cache/pip/
+  
+  before_script:
+    - pip install --upgrade pip
+    - pip install socketsecurity
+  
+  script:
+    # Run Socket CLI with minimal required parameters
+    # The CLI automatically detects:
+    # - Repository name from git
+    # - Branch name from git 
+    # - Commit SHA from git (or CI_COMMIT_SHA)
+    # - Commit message from git
+    # - Committer information from git
+    # - Default branch status from GitLab CI environment variables
+    # - Changed files from git commit
+    # - Merge request number from CI_MERGE_REQUEST_IID
+    - |
+      socketcli \
+        --target-path $CI_PROJECT_DIR \
+        --scm gitlab \
+        --pr-number ${CI_MERGE_REQUEST_IID:-0}
+  
+  # Required for GitLab integration to work properly
+  variables:
+    SOCKET_SECURITY_API_KEY: $SOCKET_SECURITY_API_KEY
+    GITLAB_TOKEN: $CI_JOB_TOKEN
+
+# Optional: Run only when manifest files change (more efficient)
+# To use this version instead, replace the rules section above with:
+#
+# rules:
+#   - if: $CI_PIPELINE_SOURCE == "push"
+#     changes:
+#       - "package.json"
+#       - "package-lock.json"
+#       - "yarn.lock"
+#       - "pnpm-lock.yaml"
+#       - "requirements.txt"
+#       - "Pipfile"
+#       - "Pipfile.lock"
+#       - "pyproject.toml"
+#       - "poetry.lock"
+#       - "go.mod"
+#       - "go.sum"
+#       - "Cargo.toml"
+#       - "Cargo.lock"
+#       - "composer.json" 
+#       - "composer.lock"
+#       - "Gemfile"
+#       - "Gemfile.lock"
+#       - "**/*.csproj"
+#       - "**/*.fsproj"
+#       - "**/*.vbproj"
+#       - "packages.config"
+#       - "paket.dependencies"
+#       - "project.json"
+#   - if: $CI_PIPELINE_SOURCE == "merge_request_event"


### PR DESCRIPTION
…behavior

<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->

Forced API Mode for non manifest file changes in a Git Repo was not correctly setting/using the default branch.

## Fix
<!-- Explain how your changes address the bug ⬇️ -->

FIXED BUGS:
- Default branch detection was not working properly in git repositories
- make_default_branch and set_as_pending_head were inconsistently set
- CLI would skip scans when manifest files hadn't changed (should always scan)
- --default-branch flag was being overridden by SCM detection
- GitLab CI integration wasn't detecting default branch correctly

CORRECTED BEHAVIOR:
- Always perform scans regardless of manifest file changes (API mode when no manifests changed)
- Proper default branch detection priority system:
  1. Explicit --default-branch flag (highest priority)
  2. CI environment variables (GitHub Actions, GitLab CI)
  3. Git repository analysis via git_repo.is_default_branch
  4. Fallback to false
- Both make_default_branch and set_as_pending_head now synchronized correctly
- Force API mode enables non-blocking behavior when no manifest files changed

ENHANCED AUTO-DETECTION:
- Repository name from git remote origin (was manual)
- Branch, commit SHA, message, and committer from git (was manual)
- Changed files from git commit (was manual)
- Better error handling for non-git repositories

SIMPLIFIED CI/CD USAGE:
- Most parameters now optional due to git auto-detection
- Added production-ready workflow examples:
  - workflows/github-actions.yml - GitHub Actions with concurrency control
  - workflows/gitlab-ci.yml - GitLab CI with environment detection
  - workflows/bitbucket-pipelines.yml - Bitbucket with path filtering
- Updated README with corrected parameter documentation

The CLI now works as users expected:
- GitHub: socketcli --target-path  --scm github --pr-number
- GitLab: socketcli --target-path  --scm gitlab --pr-number
- Local: socketcli --target-path ./project

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
- Default branch detection was not working properly in git repositories
- make_default_branch and set_as_pending_head were inconsistently set
- CLI would skip scans when manifest files hadn't changed (should always scan)
- --default-branch flag was being overridden by SCM detection
- GitLab CI integration wasn't detecting default branch correctly
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
