### PR TITLE
Automatically detect GitHub event action from event payload if not set in workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.27"
+version = "2.1.28"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.27'
+__version__ = '2.1.28'

--- a/socketsecurity/core/scm/github.py
+++ b/socketsecurity/core/scm/github.py
@@ -47,7 +47,13 @@ class GithubConfig:
         # Add debug logging
         sha = os.getenv('GITHUB_SHA', '')
         log.debug(f"Loading SHA from GITHUB_SHA: {sha}")
-        
+        event_action = os.getenv('EVENT_ACTION', None)
+        if not event_action:
+            event_path = os.getenv('GITHUB_EVENT_PATH')
+            if event_path and os.path.exists(event_path):
+                with open(event_path, 'r') as f:
+                    event = json.load(f)
+                    event_action = event.get('action')
         repository = os.getenv('GITHUB_REPOSITORY', '')
         owner = os.getenv('GITHUB_REPOSITORY_OWNER', '')
         if '/' in repository:
@@ -74,7 +80,7 @@ class GithubConfig:
             env=os.getenv('GITHUB_ENV', ''),
             token=token,
             owner=owner,
-            event_action=os.getenv('EVENT_ACTION'),
+            event_action=event_action,
             headers={
                 'Authorization': f"Bearer {token}",
                 'User-Agent': 'SocketPythonScript/0.0.1',


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->
Right now the EVENT_ACTION has to be set in the Github Workflow. Trying to simplify things and require less hard coding of variables for the end user.

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->

If the custom variable wasn't set then the EVENT_ACTION was None

## Fix
<!-- Explain how your changes address the bug ⬇️ -->

- Update the Github logic to read the event action from the GITHUB_EVENT_PATH payload file if EVENT_ACTION is not set.

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
N/A
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
