### PR TITLE
fix: robust changed file detection for PRs/MRs in GitHub, GitLab, and…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.28"
+version = "2.1.29"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.29"
+version = "2.1.30"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.30"
+version = "2.1.31"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.32"
+version = "2.1.33"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.31"
+version = "2.1.32"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.28'
+__version__ = '2.1.29'

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.29'
+__version__ = '2.1.30'

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.31'
+__version__ = '2.1.32'

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.32'
+__version__ = '2.1.33'

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.30'
+__version__ = '2.1.31'

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -389,15 +389,20 @@ class Core:
             from .utils import socket_globs as fallback_patterns
             patterns = fallback_patterns
 
+        # Normalize all file paths for matching
+        norm_files = [f.replace('\\', '/').lstrip('./') for f in files]
+
         for ecosystem in patterns:
             ecosystem_patterns = patterns[ecosystem]
             for file_name in ecosystem_patterns:
                 pattern_str = ecosystem_patterns[file_name]["pattern"]
-                for file in files:
-                    if "\\" in file:
-                        file = file.replace("\\", "/")
-                    if PurePath(file).match(pattern_str):
-                        return True
+                # Expand brace patterns for each manifest pattern
+                expanded_patterns = Core.expand_brace_pattern(pattern_str)
+                for exp_pat in expanded_patterns:
+                    for file in norm_files:
+                        # Use PurePath.match for glob-like matching
+                        if PurePath(file).match(exp_pat):
+                            return True
         return False
 
     def check_file_count_limit(self, file_count: int) -> dict:

--- a/socketsecurity/core/git_interface.py
+++ b/socketsecurity/core/git_interface.py
@@ -15,6 +15,13 @@ class Git:
         self.repo = Repo(path)
         assert self.repo
         self.head = self.repo.head
+
+        # Always fetch all remote refs to ensure branches exist for diffing
+        try:
+            self.repo.git.fetch('--all')
+            log.debug("Fetched all remote refs for diffing.")
+        except Exception as fetch_error:
+            log.debug(f"Failed to fetch all remote refs: {fetch_error}")
         
         # Use CI environment SHA if available, otherwise fall back to current HEAD commit
         github_sha = os.getenv('GITHUB_SHA')
@@ -215,8 +222,8 @@ class Git:
         self.changed_files = []
         for item in self.show_files:
             if item != "":
-                full_path = f"{self.path}/{item}"
-                self.changed_files.append(full_path)
+                # Use relative path for glob matching
+                self.changed_files.append(item)
         
         # Determine if this commit is on the default branch
         # This considers both GitHub Actions detached HEAD and regular branch situations

--- a/workflows/github-actions.yml
+++ b/workflows/github-actions.yml
@@ -15,7 +15,7 @@ on:
 
 # Prevent concurrent runs for the same commit
 concurrency:
-  group: socket-scan-${{ github.ref }}-${{ github.sha }}
+  group: socket-scan-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/workflows/github-actions.yml
+++ b/workflows/github-actions.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           # For PRs, fetch one additional commit for proper diff analysis
-          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+          fetch-depth: 0
       
       - name: Run Socket Security Scan
         env:


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->
Fixes an issue where manifest and other file changes in pull/merge requests were not detected in CI environments (GitHub Actions, GitLab CI, Bitbucket Pipelines), causing the CLI to miss important file changes in PR/MR workflows.

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->
The previous implementation only used `git show` on a single commit (often a merge commit in CI), which does not list all files changed in a PR/MR. This resulted in missing file changes, especially for manifest files, when running in CI environments for pull/merge requests.

## Fix
<!-- Explain how your changes address the bug ⬇️ -->
The detection logic now checks for PR/MR context in GitHub, GitLab, and Bitbucket using their respective environment variables. It uses `git diff` with the correct base and head refs to get the full list of changed files in a PR/MR. If not in a PR/MR context, it falls back to the original `git show` logic for single commits.

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
N/A
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug