### PR TITLE
Added logic to Ensure the repo is marked as safe for git (prevents SH…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.1.34"
+version = "2.1.35"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.1.34'
+__version__ = '2.1.35'

--- a/socketsecurity/core/git_interface.py
+++ b/socketsecurity/core/git_interface.py
@@ -412,7 +412,7 @@ class Git:
             return False
 
     @staticmethod
-    def ensure_safe_directory(self, path: str) -> None:
+    def ensure_safe_directory(path: str) -> None:
         # Ensure the repo is marked as safe for git (prevents SHA empty/dubious ownership errors)
         try :
             import subprocess


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->
The bug caused GitPython to fail in CI environments due to "dubious ownership" errors when the repository directory was not marked as safe in git config. This resulted in broken pipe and SHA empty errors during CLI execution.

Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->
GitPython requires the repository directory to be listed in git's global safe.directory config when running in some CI containers. If not, operations like commit lookup fail with errors. Previously, the code did not check or set this config, leading to failures in certain environments.

Fix
<!-- Explain how your changes address the bug ⬇️ -->
Added a helper function to check if the repository directory is already marked as safe in git config. If not, the function adds it before initializing the Repo object. This prevents the SHA empty/dubious ownership errors and ensures reliable operation in CI and local environments.

Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. --> <!-- changelog ⬇️-->
N/A

<!-- /changelog ⬆️ --> <!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->