### PR TITLE
fix passing personal access token incorrectly to Gitlab api call

### DIFF
--- a/socketsecurity/core/scm/gitlab.py
+++ b/socketsecurity/core/scm/gitlab.py
@@ -58,7 +58,7 @@ class GitlabConfig:
             repository=project_name,
             is_default_branch=(mr_source_branch == default_branch if mr_source_branch else False),
             headers={
-                'Authorization': f"Bearer {token}",
+                'PRIVATE-TOKEN': f"{token}",
                 'User-Agent': 'SocketPythonScript/0.0.1',
                 "accept": "application/json"
             }


### PR DESCRIPTION
call to gitlab api fails due to incorrecly provided personal access token (used to submit status merge request note)

## Root Cause
incorrectly using token to call gitlab api



## Fix
provide correct header based on documentation (fixes #109)

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
N/A
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
