### PR TITLE
Fixed an issue where when there were new alerts the CLI wasn't correc…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.2.4"
+version = "2.2.5"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.2.4'
+__version__ = '2.2.5'

--- a/socketsecurity/core/messages.py
+++ b/socketsecurity/core/messages.py
@@ -283,7 +283,7 @@ class Messages:
     @staticmethod
     def create_security_comment_json(diff: Diff) -> dict:
         scan_failed = False
-        if len(diff.new_alerts) == 0:
+        if len(diff.new_alerts) > 0:
             for alert in diff.new_alerts:
                 alert: Issue
                 if alert.error:


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->

CLI Is not failing scans when it should be. This means that integrations wouldn't be failed when they should be.

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->
Incorrect alert logic


## Fix
<!-- Explain how your changes address the bug ⬇️ -->

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
- Fixed the logic for failing in API Mode
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->