### PR TITLE
feat: add minimal merge commit detection support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.2.5"
+version = "2.2.6"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.2.5'
+__version__ = '2.2.6'


### PR DESCRIPTION
- Add _is_merge_commit() method to detect merge commits
- Add _detect_merge_commit_changes() method for merge commit file detection
- Use git diff with parent commit for merge commits instead of git show
- Fallback to git show if merge detection fails
- Maintains existing functionality for non-merge commits

Tested on GitHub actions. Prior to these updates, it showed no manifest file changes for merge commits and conducted a full scan. Now it picks up on the parent commit and manifest files.
