### PR TITLE
chore: add slack debugging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.2.6"
+version = "2.2.7"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.2.5"
+version = "2.2.6"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [
@@ -52,6 +52,7 @@ dev = [
 
 [project.scripts]
 socketcli = "socketsecurity.socketcli:cli"
+socketclidev = "socketsecurity.socketcli:cli"
 
 [project.urls]
 Homepage = "https://socket.dev"

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.2.5'
+__version__ = '2.2.6'

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.2.6'
+__version__ = '2.2.7'

--- a/socketsecurity/output.py
+++ b/socketsecurity/output.py
@@ -34,6 +34,22 @@ class OutputHandler:
             plugin_mgr = PluginManager({"jira": jira_config})
             plugin_mgr.send(diff_report, config=self.config)
 
+        # Debug Slack webhook configuration when debug is enabled (always show when debug is on)
+        if self.config.enable_debug:
+            import os
+            slack_enabled_env = os.getenv("SOCKET_SLACK_ENABLED", "Not set")
+            slack_config_env = os.getenv("SOCKET_SLACK_CONFIG_JSON", "Not set")
+            slack_url = "Not configured"
+            if self.config.slack_plugin.config and self.config.slack_plugin.config.get("url"):
+                slack_url = self.config.slack_plugin.config.get("url")
+            self.logger.debug("=== Slack Webhook Debug Information ===")
+            self.logger.debug(f"Slack Plugin Enabled: {self.config.slack_plugin.enabled}")
+            self.logger.debug(f"SOCKET_SLACK_ENABLED environment variable: {slack_enabled_env}")
+            self.logger.debug(f"SOCKET_SLACK_CONFIG_JSON environment variable: {slack_config_env}")
+            self.logger.debug(f"Slack Webhook URL: {slack_url}")
+            self.logger.debug(f"Slack Alert Levels: {self.config.slack_plugin.levels}")
+            self.logger.debug("=====================================")
+
         if self.config.slack_plugin.enabled:
             slack_config = {
                 "enabled": self.config.slack_plugin.enabled,


### PR DESCRIPTION
<!-- Description: Briefly describe the code improvement you're making. This could include things like lint fixes, adding monitoring dashboards, optimizing scripts, refactoring, etc. ⬇️ -->

## Description
Added comprehensive Slack webhook debugging functionality to the `--enable-debug` parameter. This improvement enhances troubleshooting capabilities for Slack webhook configuration by always displaying debug information when debug mode is enabled, regardless of whether there are security alerts or if Slack is enabled/disabled.

### Changes Made:
- **Enhanced OutputHandler**: Added Slack webhook debugging that runs whenever `--enable-debug` is used
- **Improved SlackPlugin**: Added additional debug logging for webhook execution status
- **Always-on debugging**: Moved Slack debug output outside the plugin-enabled conditional so it shows configuration status even when Slack is disabled
- **Comprehensive information display**: Shows environment variables (`SOCKET_SLACK_ENABLED`, `SOCKET_SLACK_CONFIG_JSON`), webhook URL, plugin status, and alert levels

### Debug Output Includes:
- Slack Plugin enabled/disabled status
- Environment variable values and status
- Configured webhook URL or "Not configured" status
- Alert levels configuration
- Additional plugin execution details when alerts are present

This improvement makes it significantly easier for users to troubleshoot Slack webhook setup issues and verify their configuration is correct.

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog. -->

<!-- changelog ⬇️-->
### Improvements
- Enhanced `--enable-debug` output to always display Slack webhook configuration information, making it easier to troubleshoot webhook setup issues
<!-- /changelog ⬆️ -->

<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-improvement -->