### PR TITLE
feat: Add SCM-aware manifest file URL generation and fix report links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.2.7"
+version = "2.2.8"
 requires-python = ">= 3.10"
 license = {"file" = "LICENSE"}
 dependencies = [
@@ -16,7 +16,7 @@ dependencies = [
     'GitPython',
     'packaging',
     'python-dotenv',
-    'socketdev>=3.0.0,<4.0.0'
+    'socketdev>=3.0.5,<4.0.0'
 ]
 readme = "README.md"
 description = "Socket Security CLI for CI/CD"

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'socket.dev'
-__version__ = '2.2.7'
+__version__ = '2.2.8'

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -451,13 +451,14 @@ class Core:
         log.debug(f"Created temporary empty file for baseline scan: {temp_path}")
         return [temp_path]
 
-    def create_full_scan(self, files: List[str], params: FullScanParams) -> FullScan:
+    def create_full_scan(self, files: List[str], params: FullScanParams, base_path: str = None) -> FullScan:
         """
         Creates a new full scan via the Socket API.
 
         Args:
             files: List of file paths to scan
             params: Parameters for the full scan
+            base_path: Base path for the scan (optional)
 
         Returns:
             FullScan object with scan results
@@ -465,7 +466,7 @@ class Core:
         log.info("Creating new full scan")
         create_full_start = time.time()
 
-        res = self.sdk.fullscans.post(files, params, use_types=True, use_lazy_loading=True, max_open_files=50)
+        res = self.sdk.fullscans.post(files, params, use_types=True, use_lazy_loading=True, max_open_files=50, base_path=base_path)
         if not res.success:
             log.error(f"Error creating full scan: {res.message}, status: {res.status}")
             raise Exception(f"Error creating full scan: {res.message}, status: {res.status}")
@@ -523,7 +524,7 @@ class Core:
         try:
             # Create new scan
             new_scan_start = time.time()
-            new_full_scan = self.create_full_scan(files, params)
+            new_full_scan = self.create_full_scan(files, params, base_path=path)
             new_scan_end = time.time()
             log.info(f"Total time to create new full scan: {new_scan_end - new_scan_start:.2f}")
         except APIFailure as e:
@@ -899,7 +900,7 @@ class Core:
             # Create baseline scan with empty file
             empty_files = Core.empty_head_scan_file()
             try:
-                head_full_scan = self.create_full_scan(empty_files, tmp_params)
+                head_full_scan = self.create_full_scan(empty_files, tmp_params, base_path=path)
                 head_full_scan_id = head_full_scan.id
                 log.debug(f"Created empty baseline scan: {head_full_scan_id}")
                 
@@ -922,7 +923,7 @@ class Core:
         # Create new scan
         try:
             new_scan_start = time.time()
-            new_full_scan = self.create_full_scan(files, params)
+            new_full_scan = self.create_full_scan(files, params, base_path=path)
             new_scan_end = time.time()
             log.info(f"Total time to create new full scan: {new_scan_end - new_scan_start:.2f}")
         except APIFailure as e:

--- a/socketsecurity/socketcli.py
+++ b/socketsecurity/socketcli.py
@@ -275,7 +275,7 @@ def main_code():
             overview_comment = Messages.dependency_overview_template(diff)
             log.debug("Creating Security Issues Comment")
             
-            security_comment = Messages.security_comment_template(diff)
+            security_comment = Messages.security_comment_template(diff, config)
             
             new_security_comment = True
             new_overview_comment = True

--- a/uv.lock
+++ b/uv.lock
@@ -1027,20 +1027,20 @@ wheels = [
 
 [[package]]
 name = "socketdev"
-version = "3.0.0"
+version = "3.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/4f/07cb8e4e827931527a3c04e3520dabed8f20ece5a5fb91e5a012e6bb2446/socketdev-3.0.0.tar.gz", hash = "sha256:27c22d3a016e06b916f373f78edd34dc6d7612da0ae845e8e383d58d7425e5bb", size = 101362, upload-time = "2025-08-23T22:59:02.855Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/b7/fe90d55105df76e9ff3af025f64b2d2b515c30ac0866a9973a093f25c5ed/socketdev-3.0.5.tar.gz", hash = "sha256:58cbe8613c3c892cdbae4941cb53f065051f8e991500d9d61618b214acf4ffc2", size = 129576, upload-time = "2025-09-09T07:15:48.232Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/c4/ed98ab0022f19c8e7ded5a2eaea0f0cabf829c6e7001bb7cf8ae112e964f/socketdev-3.0.0-py3-none-any.whl", hash = "sha256:f142f3b0d22a32479cf73bd35f9a0bdcd4896e494c60fdeb2999c0daa9682611", size = 48942, upload-time = "2025-08-23T22:59:01.134Z" },
+    { url = "https://files.pythonhosted.org/packages/de/05/c3fc7d0418c2598302ad4b0baf111fa492b31a8fa14acfa394af6f55b373/socketdev-3.0.5-py3-none-any.whl", hash = "sha256:e050f50d2c6b4447107edd3368b56b053e1df62056d424cc1616e898303638ef", size = 55083, upload-time = "2025-09-09T07:15:46.52Z" },
 ]
 
 [[package]]
 name = "socketsecurity"
-version = "2.2.3"
+version = "2.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },
@@ -1084,7 +1084,7 @@ requires-dist = [
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
-    { name = "socketdev", specifier = ">=3.0.0,<4.0.0" },
+    { name = "socketdev", specifier = ">=3.0.5,<4.0.0" },
     { name = "twine", marker = "extra == 'dev'" },
     { name = "uv", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->

**Bug Description:**
Manifest files in security comments were incorrectly linking to Socket dashboard URLs (like `https://socket.dev/dashboard/org/socketdev-demo/diff/06e956ff...`) instead of proper SCM URLs (like `https://github.com/socketdev-demo/javascript-threats/blob/main/package.json`) when `scm=github/gitlab/bitbucket`. Additionally, "View full report" links were using the wrong URL type for different scan contexts.

**Impact:**
- Users clicking on manifest file links were redirected to Socket's dashboard instead of the actual source code file in their repository
- This broke the workflow for developers trying to quickly navigate to the problematic files
- "View full report" links pointed to SBOM reports instead of diff reports in PR contexts

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->

The `Messages.security_comment_template()` method was directly using `alert.manifests` as href URLs without any processing. The manifest paths contained build agent paths and weren't converted to proper SCM URLs based on the repository type. Additionally, the method was missing logic to generate SCM-specific URLs using repository configuration and environment variables.

The "View full report" link was hardcoded to use `report_url` instead of intelligently choosing between `diff_url` (for PR comparisons) and `report_url` (for SBOM views).

## Fix
<!-- Explain how your changes address the bug ⬇️ -->

1. **Added `get_manifest_file_url()` method** that intelligently generates proper URLs based on SCM type:
   - Cleans up manifest paths by removing build agent prefixes (`opt/buildagent/work/`, `home/runner/work/`)
   - Detects SCM type from config or diff URL (GitHub, GitLab, Bitbucket)
   - Constructs proper SCM URLs using repository info and environment variables
   - Supports custom servers via `GITHUB_SERVER_URL`, `CI_SERVER_URL`, `BITBUCKET_SERVER_URL`
   - Falls back to Socket file view for API mode

2. **Updated `security_comment_template()` method** to:
   - Use `get_manifest_file_url()` for both security alerts and license violations
   - Accept config parameter for SCM type detection
   - Fix "View full report" logic to prioritize `diff_url` for PRs, fallback to `report_url` for non-PR scans

3. **Enhanced infrastructure:**
   - Added `os` module import for environment variable access
   - Updated method signatures and type hints
   - Added `base_path` parameter to `create_full_scan()` for better path handling

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
Fixed manifest file links in security comments to properly link to source code files in GitHub, GitLab, and Bitbucket repositories instead of Socket dashboard pages. Fixed "View full report" links to show appropriate content based on scan context.
<!-- /changelog ⬆️ -->

<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->