### PR TITLE
fix: strip git name-rev suffix operators from detected branch name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.83
+
+- Fixed branch detection in detached-HEAD CI checkouts. When `git name-rev --name-only HEAD` returned an output with a suffix operator (e.g. `remotes/origin/master~1`, `master^0`), the `~N`/`^N` was previously passed through as the branch name and rejected by the Socket API as an invalid Git ref. The suffix is now stripped before the prefix split, producing the bare branch name.
+
 ## 2.2.71
 
 - Added `strace` to the Docker image for debugging purposes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.2.82"
+version = "2.2.83"
 requires-python = ">= 3.11"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.2.82'
+__version__ = '2.2.83'
 USER_AGENT = f'SocketPythonCLI/{__version__}'

--- a/socketsecurity/core/git_interface.py
+++ b/socketsecurity/core/git_interface.py
@@ -1,3 +1,4 @@
+import re
 import urllib.parse
 import os
 
@@ -108,6 +109,11 @@ class Git:
                     # Try git name-rev first (most reliable for detached HEAD)
                     result = self.repo.git.name_rev('--name-only', 'HEAD')
                     if result and result != 'undefined':
+                        # Strip name-rev suffix operators (~N, ^N, or combinations
+                        # like master~3^2). These characters are forbidden in git
+                        # ref names, so cutting at the first occurrence can never
+                        # truncate a real branch name.
+                        result = re.split(r'[~^]', result, maxsplit=1)[0]
                         # Clean up the result (remove any prefixes like 'remotes/origin/')
                         git_detected_branch = result.split('/')[-1]
                         log.debug(f"Branch detected from git name-rev: {git_detected_branch}")


### PR DESCRIPTION
## Summary

In detached-HEAD CI checkouts (Buildkite, CircleCI, Jenkins, and anything else not explicitly detected via `GITHUB_REF` / `CI_COMMIT_BRANCH` / `BITBUCKET_BRANCH`), the CLI falls back to `git name-rev --name-only HEAD` for branch detection. When the checked-out SHA isn't exactly at a branch tip — typically because a new commit landed on the target branch between pipeline trigger and scan start — `name-rev` returns output with a suffix operator:

- `remotes/origin/master~1` (one commit behind master)
- `master^0` (alternate form for exact tip)
- `remotes/origin/master~3^2`

The existing `split('/')[-1]` cleanup only strips the `remotes/origin/` prefix; the `~N`/`^N` suffix survived and was sent to the Socket API as the branch name. The API then rejected it because `~` and `^` are forbidden characters in Git ref names, producing the error:

> `Invalid branch name: Branch names must follow Git branch name rules: ... cannot include ... ~^:?*[`

The fix strips anything from the first `~` or `^` onward before the prefix split. Both characters are forbidden in Git ref names per `check-ref-format(1)`, so cutting at them can never truncate a real branch name.

## Verification

Reproduced end-to-end against a test repo in detached HEAD where `git name-rev --name-only HEAD` returned `remotes/origin/master~1`:

| Version | URL branch param | Outcome |
|---|---|---|
| PyPI `socketsecurity==2.2.81` (unpatched) | `branch=master~1` | 400 "Invalid branch name" |
| This branch | `branch=master` | Full scan created |

## Test plan

- [x] Unit-level: `Git(path).branch` returns `master` when `git name-rev` outputs `remotes/origin/master~1`
- [x] End-to-end: scan against test repo in detached HEAD succeeds
- [x] Confirmed the unpatched PyPI release exhibits the bug
- [ ] CI checks pass