### PR TITLE
Add hidden reach-continue-on-* flags for Coana v15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.2.84"
+version = "2.2.85"
 requires-python = ">= 3.11"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.2.84'
+__version__ = '2.2.85'
 USER_AGENT = f'SocketPythonCLI/{__version__}'

--- a/socketsecurity/config.py
+++ b/socketsecurity/config.py
@@ -131,6 +131,10 @@ class CliConfig:
     reach_additional_params: Optional[List[str]] = None
     only_facts_file: bool = False
     reach_use_only_pregenerated_sboms: bool = False
+    reach_continue_on_analysis_errors: bool = False
+    reach_continue_on_install_errors: bool = False
+    reach_continue_on_missing_lock_files: bool = False
+    reach_continue_on_no_source_files: bool = False
     max_purl_batch_size: int = 5000
     enable_commit_status: bool = False
     config_file: Optional[str] = None
@@ -236,6 +240,10 @@ class CliConfig:
             'reach_additional_params': args.reach_additional_params,
             'only_facts_file': args.only_facts_file,
             'reach_use_only_pregenerated_sboms': args.reach_use_only_pregenerated_sboms,
+            'reach_continue_on_analysis_errors': args.reach_continue_on_analysis_errors,
+            'reach_continue_on_install_errors': args.reach_continue_on_install_errors,
+            'reach_continue_on_missing_lock_files': args.reach_continue_on_missing_lock_files,
+            'reach_continue_on_no_source_files': args.reach_continue_on_no_source_files,
             'max_purl_batch_size': args.max_purl_batch_size,
             'enable_commit_status': args.enable_commit_status,
             'config_file': args.config_file,
@@ -860,6 +868,30 @@ def create_argument_parser() -> argparse.ArgumentParser:
         dest="reach_use_only_pregenerated_sboms",
         action="store_true",
         help="When using this option, the scan is created based only on pre-generated CDX and SPDX files in your project. (requires --reach)"
+    )
+    reachability_group.add_argument(
+        "--reach-continue-on-analysis-errors",
+        dest="reach_continue_on_analysis_errors",
+        action="store_true",
+        help=argparse.SUPPRESS
+    )
+    reachability_group.add_argument(
+        "--reach-continue-on-install-errors",
+        dest="reach_continue_on_install_errors",
+        action="store_true",
+        help=argparse.SUPPRESS
+    )
+    reachability_group.add_argument(
+        "--reach-continue-on-missing-lock-files",
+        dest="reach_continue_on_missing_lock_files",
+        action="store_true",
+        help=argparse.SUPPRESS
+    )
+    reachability_group.add_argument(
+        "--reach-continue-on-no-source-files",
+        dest="reach_continue_on_no_source_files",
+        action="store_true",
+        help=argparse.SUPPRESS
     )
 
     parser.add_argument(

--- a/socketsecurity/core/tools/reachability.py
+++ b/socketsecurity/core/tools/reachability.py
@@ -104,6 +104,10 @@ class ReachabilityAnalyzer:
         allow_unverified: bool = False,
         enable_debug: bool = False,
         use_only_pregenerated_sboms: bool = False,
+        continue_on_analysis_errors: bool = False,
+        continue_on_install_errors: bool = False,
+        continue_on_missing_lock_files: bool = False,
+        continue_on_no_source_files: bool = False,
     ) -> Dict[str, Any]:
         """
         Run reachability analysis.
@@ -195,6 +199,18 @@ class ReachabilityAnalyzer:
 
         if use_only_pregenerated_sboms:
             cmd.append("--use-only-pregenerated-sboms")
+
+        if continue_on_analysis_errors:
+            cmd.append("--reach-continue-on-analysis-errors")
+
+        if continue_on_install_errors:
+            cmd.append("--reach-continue-on-install-errors")
+
+        if continue_on_missing_lock_files:
+            cmd.append("--reach-continue-on-missing-lock-files")
+
+        if continue_on_no_source_files:
+            cmd.append("--reach-continue-on-no-source-files")
 
         # Add any additional parameters provided by the user
         if additional_params:

--- a/socketsecurity/socketcli.py
+++ b/socketsecurity/socketcli.py
@@ -303,7 +303,11 @@ def main_code():
                     additional_params=config.reach_additional_params,
                     allow_unverified=config.allow_unverified,
                     enable_debug=config.enable_debug,
-                    use_only_pregenerated_sboms=config.reach_use_only_pregenerated_sboms
+                    use_only_pregenerated_sboms=config.reach_use_only_pregenerated_sboms,
+                    continue_on_analysis_errors=config.reach_continue_on_analysis_errors,
+                    continue_on_install_errors=config.reach_continue_on_install_errors,
+                    continue_on_missing_lock_files=config.reach_continue_on_missing_lock_files,
+                    continue_on_no_source_files=config.reach_continue_on_no_source_files,
                 )
                 
                 log.info(f"Reachability analysis completed successfully")


### PR DESCRIPTION
## Summary

Preparation for the upcoming **Coana CLI v15** major release.

Coana v15 changes the default halt behavior in socket mode for four different failure conditions, and introduces matching `--reach-continue-on-*` flags to opt out of each halt. This PR adds those four flags to the Python CLI as **hidden** argparse options (via `help=argparse.SUPPRESS`) and forwards them through `ReachabilityAnalyzer.run_reachability_analysis` to the spawned `coana run` command. Nothing changes for users today — the flags are no-ops against the current default Coana version — but the Python CLI will forward them as soon as Coana v15 becomes the default.

### New flags (all hidden from `--help`)

| Python CLI flag | Forwards to Coana | Halt it opts out of |
|---|---|---|
| `--reach-continue-on-analysis-errors` | `--reach-continue-on-analysis-errors` | Timeouts, OOM, parse errors, low-confidence results |
| `--reach-continue-on-install-errors` | `--reach-continue-on-install-errors` | Package installation failures |
| `--reach-continue-on-missing-lock-files` | `--reach-continue-on-missing-lock-files` | Gradle/SBT projects missing lockfile / version catalog / pre-generated SBOM |
| `--reach-continue-on-no-source-files` | `--reach-continue-on-no-source-files` | Workspace with no source files for its ecosystem |

When the flag is set, the corresponding argument is appended to the `coana run` argv; when it's unset, nothing is appended and Coana applies its own default.

### Files touched

- `socketsecurity/config.py` — `CliConfig` fields, argparse options (`help=argparse.SUPPRESS`), and `config_args` wiring
- `socketsecurity/core/tools/reachability.py` — new `continue_on_*` kwargs on `run_reachability_analysis` + argv forwarding
- `socketsecurity/socketcli.py` — pass config values through to the analyzer

## Test plan

- [x] All 33 tests in `tests/unit/test_config.py` + `tests/unit/test_cli_config.py` pass
- [x] Manual parse check: all four flags resolve to `True` on the config when passed
- [x] Manual `--help` check: all four flags are absent from help output
- [ ] Smoke-test against a Coana v15 build once one is available to confirm the flags propagate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)