### PR TITLE
Add initial bun and vlt lockfile support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.2.86"
+version = "2.2.88"
 requires-python = ">= 3.11"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.2.86'
+__version__ = '2.2.87'
 USER_AGENT = f'SocketPythonCLI/{__version__}'

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.2.87'
+__version__ = '2.2.88'
 USER_AGENT = f'SocketPythonCLI/{__version__}'

--- a/socketsecurity/core/utils.py
+++ b/socketsecurity/core/utils.py
@@ -38,6 +38,12 @@ socket_globs = {
         },
         "pnpm-workspace.yml": {
             "pattern": "pnpm-workspace.yml"
+        },
+        "bun.lock": {
+            "pattern": "bun.lock"
+        },
+        "vlt-lock.json": {
+            "pattern": "vlt-lock.json"
         }
     },
     "pypi": {

--- a/socketsecurity/core/utils.py
+++ b/socketsecurity/core/utils.py
@@ -42,6 +42,9 @@ socket_globs = {
         "bun.lock": {
             "pattern": "bun.lock"
         },
+        "bun.lockb": {
+            "pattern": "bun.lockb"
+        },
         "vlt-lock.json": {
             "pattern": "vlt-lock.json"
         }

--- a/tests/core/test_has_manifest_files.py
+++ b/tests/core/test_has_manifest_files.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from socketsecurity.core import Core
+from socketsecurity.core.utils import socket_globs
 
 # Minimal patterns matching what the Socket API returns
 MOCK_PATTERNS = {
@@ -8,6 +9,9 @@ MOCK_PATTERNS = {
         "packagejson": {"pattern": "package.json"},
         "packagelockjson": {"pattern": "package-lock.json"},
         "yarnlock": {"pattern": "yarn.lock"},
+        "bunlock": {"pattern": "bun.lock"},
+        "bunlockb": {"pattern": "bun.lockb"},
+        "vltlockjson": {"pattern": "vlt-lock.json"},
     },
     "pypi": {
         "requirements": {"pattern": "*requirements.txt"},
@@ -66,3 +70,42 @@ class TestHasManifestFiles:
     def test_pom_xml_root(self, mock_patterns):
         core = Core.__new__(Core)
         assert core.has_manifest_files(["pom.xml"]) is True
+
+    def test_bun_lock_root(self, mock_patterns):
+        core = Core.__new__(Core)
+        assert core.has_manifest_files(["bun.lock"]) is True
+
+    def test_bun_lockb_root(self, mock_patterns):
+        core = Core.__new__(Core)
+        assert core.has_manifest_files(["bun.lockb"]) is True
+
+    def test_vlt_lock_json_root(self, mock_patterns):
+        core = Core.__new__(Core)
+        assert core.has_manifest_files(["vlt-lock.json"]) is True
+
+    def test_bun_lock_subdirectory(self, mock_patterns):
+        core = Core.__new__(Core)
+        assert core.has_manifest_files(["apps/web/bun.lock"]) is True
+
+
+@patch.object(Core, "get_supported_patterns", side_effect=RuntimeError("API unreachable"))
+@patch.object(Core, "__init__", lambda self, *a, **kw: None)
+class TestHasManifestFilesFallback:
+    """Exercises the socket_globs fallback path used when the Socket API is unreachable."""
+
+    def test_fallback_matches_bun_lock(self, mock_patterns):
+        core = Core.__new__(Core)
+        assert core.has_manifest_files(["bun.lock"]) is True
+
+    def test_fallback_matches_bun_lockb(self, mock_patterns):
+        core = Core.__new__(Core)
+        assert core.has_manifest_files(["bun.lockb"]) is True
+
+    def test_fallback_matches_vlt_lock_json(self, mock_patterns):
+        core = Core.__new__(Core)
+        assert core.has_manifest_files(["vlt-lock.json"]) is True
+
+    def test_fallback_patterns_dict_contains_new_entries(self, mock_patterns):
+        assert "bun.lock" in socket_globs["npm"]
+        assert "bun.lockb" in socket_globs["npm"]
+        assert "vlt-lock.json" in socket_globs["npm"]


### PR DESCRIPTION
The python CLI fails to locate `bun.lock` and `vlt-lock.json` files, preventing them from being analyzed by developers using the CLI. This PR adds them to the hard-coded list.

⚠️ **Note:** Additional backend work is still required to properly ingest and scan these filetypes.

<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->

## Root Cause
<!-- Concise explanation of what caused the bug ⬇️ -->

Experimental bun/vlt SBOM resolution support was added but not propagated to the CLI's list of supported files.

## Fix
<!-- Explain how your changes address the bug ⬇️ -->

This PR simply adds the patterns to the hard-coded list of patterns.

## Public Changelog
<!-- Write a changelog message between comment tags if this should be included in the public product changelog, Leave blank otherwise. -->

<!-- changelog ⬇️-->
Add bun.lock and vlt-lock.json to supported manifest types.
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->