### PR TITLE
Fix uv lockfile sync + version incrementation checks

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -6,6 +6,7 @@ on:
       - 'socketsecurity/**'
       - 'setup.py'
       - 'pyproject.toml'
+      - 'uv.lock'
 
 permissions:
   contents: read
@@ -45,6 +46,18 @@ jobs:
               exit(1)
           print(f'✅ Version properly incremented from {main_ver} to {pr_ver}')
           "
+
+      - name: Require uv.lock update when pyproject changes
+        run: |
+          CHANGED_FILES="$(git diff --name-only origin/main...HEAD)"
+
+          if echo "$CHANGED_FILES" | grep -qx 'pyproject.toml'; then
+            if ! echo "$CHANGED_FILES" | grep -qx 'uv.lock'; then
+              echo "❌ pyproject.toml changed, but uv.lock was not updated."
+              echo "Run 'uv lock' and commit uv.lock with the version bump."
+              exit 1
+            fi
+          fi
 
       - name: Manage PR Comment
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -4,7 +4,6 @@ on:
     types: [opened, synchronize, ready_for_review]
     paths:
       - 'socketsecurity/**'
-      - 'setup.py'
       - 'pyproject.toml'
       - 'uv.lock'
 

--- a/.hooks/sync_version.py
+++ b/.hooks/sync_version.py
@@ -8,6 +8,7 @@ import json
 
 INIT_FILE = pathlib.Path("socketsecurity/__init__.py")
 PYPROJECT_FILE = pathlib.Path("pyproject.toml")
+UV_LOCK_FILE = pathlib.Path("uv.lock")
 
 VERSION_PATTERN = re.compile(r"__version__\s*=\s*['\"]([^'\"]+)['\"]")
 PYPROJECT_PATTERN = re.compile(r'^version\s*=\s*".*"$', re.MULTILINE)
@@ -72,6 +73,21 @@ def inject_version(version: str):
         new_pyproject = re.sub(r"(\[project\])", rf"\1\nversion = \"{version}\"", pyproject)
     PYPROJECT_FILE.write_text(new_pyproject)
 
+
+def run_uv_lock() -> bool:
+    before = UV_LOCK_FILE.read_bytes() if UV_LOCK_FILE.exists() else b""
+    try:
+        subprocess.run(["uv", "lock"], check=True, text=True)
+    except FileNotFoundError:
+        print("❌ `uv` is required but was not found in PATH.")
+        sys.exit(1)
+    except subprocess.CalledProcessError:
+        print("❌ `uv lock` failed. Please run it manually and fix any errors.")
+        sys.exit(1)
+
+    after = UV_LOCK_FILE.read_bytes() if UV_LOCK_FILE.exists() else b""
+    return before != after
+
 def main():
     dev_mode = "--dev" in sys.argv
     current_version = read_version_from_init(INIT_FILE)
@@ -84,15 +100,24 @@ def main():
             base_version = current_version.split(".dev")[0] if ".dev" in current_version else current_version
             new_version = find_next_available_dev_version(base_version)
             inject_version(new_version)
-            print("⚠️ Version was unchanged — auto-bumped. Please git add + commit again.")
+            uv_lock_changed = run_uv_lock()
+            lock_hint = " and uv.lock" if uv_lock_changed else ""
+            print(f"⚠️ Version was unchanged — auto-bumped. Please git add{lock_hint} + commit again.")
             sys.exit(0)
         else:
             new_version = bump_patch_version(current_version)
             inject_version(new_version)
-            print("⚠️ Version was unchanged — auto-bumped. Please git add + commit again.")
+            uv_lock_changed = run_uv_lock()
+            lock_hint = " and uv.lock" if uv_lock_changed else ""
+            print(f"⚠️ Version was unchanged — auto-bumped. Please git add{lock_hint} + commit again.")
             sys.exit(1)
     else:
-        print("✅ Version already bumped — proceeding.")
+        uv_lock_changed = run_uv_lock()
+        if uv_lock_changed:
+            print("⚠️ Version already bumped, but uv.lock was out of date and has been updated. Please git add uv.lock + commit again.")
+            sys.exit(1)
+
+        print("✅ Version already bumped and uv.lock is up to date — proceeding.")
         sys.exit(0)
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.2.88"
+version = "2.2.89"
 requires-python = ">= 3.11"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.2.88'
+__version__ = '2.2.89'
 USER_AGENT = f'SocketPythonCLI/{__version__}'

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "socketsecurity"
-version = "2.2.86"
+version = "2.2.88"
 source = { editable = "." }
 dependencies = [
     { name = "bs4" },

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "socketsecurity"
-version = "2.2.88"
+version = "2.2.89"
 source = { editable = "." }
 dependencies = [
     { name = "bs4" },


### PR DESCRIPTION
## Summary

- Revs `uv.lock` up to v2.2.89 to account for mandatory Version Check (was previously v2.2.88 from v2.2.86)
- Updates Python hook to sync uv lockfile is with any `pyproject.toml` and `__init__.py` version bumps
- Updates Version Check workflow to ensure the `uv.lock` file contains the incremented version