### PR TITLE
fix(core): fall back to humanized title for unmapped alert types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.2.91"
+version = "2.2.92"
 requires-python = ">= 3.11"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.2.91'
+__version__ = '2.2.92'
 USER_AGENT = f'SocketPythonCLI/{__version__}'

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import sys
 import tarfile
 import tempfile
@@ -43,6 +44,26 @@ __all__ = [
 
 version = __version__
 log = logging.getLogger("socketdev")
+
+_ALERT_TYPE_TITLE_OVERRIDES = {
+    "gptDidYouMean": "Possible typosquat attack (GPT)",
+}
+
+_HUMANIZE_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+
+
+def _humanize_alert_type(alert_type: str) -> str:
+    """Convert a camelCase/PascalCase alert type into a Title-Cased label.
+
+    Used as a last-resort fallback when the SDK does not have metadata for an
+    alert type and there is no explicit override. Adjacent capitals are kept
+    together so acronyms like 'SQL' survive ('SQLInjection' -> 'SQL Injection').
+    """
+    if not alert_type:
+        return ""
+    parts = _HUMANIZE_BOUNDARY.split(alert_type)
+    return " ".join(part[:1].upper() + part[1:] for part in parts if part)
+
 
 class Core:
     """Main class for interacting with Socket Security API and processing scan results."""

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -1423,11 +1423,19 @@ class Core:
             alert = Alert(**alert_item)
             props = getattr(self.config.all_issues, alert.type, default_props)
             introduced_by = self.get_source_data(package, packages)
-            
-            # Handle special case for license policy violations
+
+            # Title resolution order:
+            #   1. SDK-provided title (props.title) if non-empty
+            #   2. Explicit override for known-but-unmapped alert types (e.g. gptDidYouMean)
+            #   3. Hard-coded special cases (e.g. licenseSpdxDisj)
+            #   4. Humanized alert.type as last-resort fallback
             title = props.title
-            if alert.type == "licenseSpdxDisj" and not title:
+            if not title:
+                title = _ALERT_TYPE_TITLE_OVERRIDES.get(alert.type, "")
+            if not title and alert.type == "licenseSpdxDisj":
                 title = "License Policy Violation"
+            if not title:
+                title = _humanize_alert_type(alert.type)
             
             issue_alert = Issue(
                 pkg_type=package.type,

--- a/tests/core/test_package_and_alerts.py
+++ b/tests/core/test_package_and_alerts.py
@@ -186,6 +186,24 @@ class TestPackageAndAlerts:
         assert alert.title, "title should not be empty for gptDidYouMean"
         assert "typosquat" in alert.title.lower()
 
+    def test_unknown_alert_type_falls_back_to_humanized_title(self, core):
+        """Any alert type not present in the SDK should still render a non-empty title."""
+        package = self.make_package(
+            alerts=[{
+                "type": "someBrandNewAlertType",
+                "key": "future-alert",
+                "severity": "low",
+            }],
+            topLevelAncestors=[],
+        )
+
+        result = core.add_package_alerts_to_collection(
+            package, alerts_collection={}, packages={package.id: package}
+        )
+
+        alert = result["future-alert"][0]
+        assert alert.title == "Some Brand New Alert Type"
+
 
 
     def test_get_capabilities_for_added_packages(self, core):

--- a/tests/core/test_package_and_alerts.py
+++ b/tests/core/test_package_and_alerts.py
@@ -322,3 +322,27 @@ class TestPackageAndAlerts:
         )
         assert result["npm/lodash@4.18.1"].licenseAttrib == [{"name": "MIT"}]
         assert result["npm/lodash@4.18.1"].licenseDetails == [{"license": "MIT"}]
+
+
+class TestHumanizeAlertType:
+    def test_humanizes_camel_case(self):
+        from socketsecurity.core import _humanize_alert_type
+        assert _humanize_alert_type("gptDidYouMean") == "Gpt Did You Mean"
+
+    def test_humanizes_single_word(self):
+        from socketsecurity.core import _humanize_alert_type
+        assert _humanize_alert_type("malware") == "Malware"
+
+    def test_humanizes_pascal_case(self):
+        from socketsecurity.core import _humanize_alert_type
+        assert _humanize_alert_type("UnsafeShellAccess") == "Unsafe Shell Access"
+
+    def test_empty_input_returns_empty_string(self):
+        from socketsecurity.core import _humanize_alert_type
+        assert _humanize_alert_type("") == ""
+
+    def test_handles_acronyms_conservatively(self):
+        """Adjacent capitals are kept together: SQLInjection -> 'SQL Injection'."""
+        from socketsecurity.core import _humanize_alert_type
+        assert _humanize_alert_type("SQLInjection") == "SQL Injection"
+

--- a/tests/core/test_package_and_alerts.py
+++ b/tests/core/test_package_and_alerts.py
@@ -166,6 +166,26 @@ class TestPackageAndAlerts:
         assert alert.type == "networkAccess"
         assert alert.severity == "high"
 
+    def test_gpt_did_you_mean_gets_typosquat_title(self, core):
+        """gptDidYouMean alerts must render a non-empty title (CUS2-2)."""
+        package = self.make_package(
+            alerts=[{
+                "type": "gptDidYouMean",
+                "key": "gpt-did-you-mean-alert",
+                "severity": "middle",
+            }],
+            topLevelAncestors=[],
+        )
+
+        result = core.add_package_alerts_to_collection(
+            package, alerts_collection={}, packages={package.id: package}
+        )
+
+        alert = result["gpt-did-you-mean-alert"][0]
+        assert alert.type == "gptDidYouMean"
+        assert alert.title, "title should not be empty for gptDidYouMean"
+        assert "typosquat" in alert.title.lower()
+
 
 
     def test_get_capabilities_for_added_packages(self, core):

--- a/tests/core/test_package_and_alerts.py
+++ b/tests/core/test_package_and_alerts.py
@@ -204,6 +204,24 @@ class TestPackageAndAlerts:
         alert = result["future-alert"][0]
         assert alert.title == "Some Brand New Alert Type"
 
+    def test_license_spdx_disj_keeps_explicit_title(self, core):
+        """licenseSpdxDisj must keep its hard-coded fallback (regression guard for CUS2-2 fix)."""
+        package = self.make_package(
+            alerts=[{
+                "type": "licenseSpdxDisj",
+                "key": "license-alert",
+                "severity": "high",
+            }],
+            topLevelAncestors=[],
+        )
+
+        result = core.add_package_alerts_to_collection(
+            package, alerts_collection={}, packages={package.id: package}
+        )
+
+        alert = result["license-alert"][0]
+        assert alert.title == "License Policy Violation"
+
 
 
     def test_get_capabilities_for_added_packages(self, core):

--- a/tests/core/test_package_and_alerts.py
+++ b/tests/core/test_package_and_alerts.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 from socketdev import socketdev
 
-from socketsecurity.core import Core
+from socketsecurity.core import Core, _humanize_alert_type
 from socketsecurity.core.classes import Issue, Package
 from socketsecurity.core.socket_config import SocketConfig
 
@@ -326,23 +326,18 @@ class TestPackageAndAlerts:
 
 class TestHumanizeAlertType:
     def test_humanizes_camel_case(self):
-        from socketsecurity.core import _humanize_alert_type
         assert _humanize_alert_type("gptDidYouMean") == "Gpt Did You Mean"
 
     def test_humanizes_single_word(self):
-        from socketsecurity.core import _humanize_alert_type
         assert _humanize_alert_type("malware") == "Malware"
 
     def test_humanizes_pascal_case(self):
-        from socketsecurity.core import _humanize_alert_type
         assert _humanize_alert_type("UnsafeShellAccess") == "Unsafe Shell Access"
 
     def test_empty_input_returns_empty_string(self):
-        from socketsecurity.core import _humanize_alert_type
         assert _humanize_alert_type("") == ""
 
     def test_handles_acronyms_conservatively(self):
         """Adjacent capitals are kept together: SQLInjection -> 'SQL Injection'."""
-        from socketsecurity.core import _humanize_alert_type
         assert _humanize_alert_type("SQLInjection") == "SQL Injection"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ wheels = [
 
 [[package]]
 name = "socketsecurity"
-version = "2.2.91"
+version = "2.2.92"
 source = { editable = "." }
 dependencies = [
     { name = "bs4" },


### PR DESCRIPTION
Fixes [CE-207](https://linear.app/socketdev/issue/CE-207). Webflow's CI was blocking on `is-typed-array@1.1.15` via Socket CLI 2.2.86, but the Alert column for that row rendered blank. The API returns a single `gptDidYouMean` alert; the bundled `socketdev` SDK had no class for that type, so `alert.title` was empty and the table rendered nothing for that row.

## Root Cause

`socket-python-cli` resolves alert titles via the `socketdev` SDK's `AllIssues` registry. When the API emits an alert type that has no corresponding class on `AllIssues` — `gptDidYouMean` being the case Webflow hit — `alert.title` is empty and every downstream consumer (the CLI's console table, SARIF report, PR/security comments) renders blank. There was no fallback.

The upstream cause is that `socket-sdk-python`'s `AllIssues` is hand-maintained and never got `gptDidYouMean` added. That's tracked in [CE-206](https://linear.app/socketdev/issue/CE-206) (in progress) and is the proper long-term fix.

## Fix

Title resolution in `Core.add_package_alerts_to_collection` is now a four-step ladder:

1. SDK-provided title (`props.title`) if non-empty
2. Explicit override map (`_ALERT_TYPE_TITLE_OVERRIDES`) — currently maps `gptDidYouMean` → `"Possible typosquat attack (GPT)"`
3. Existing `licenseSpdxDisj` special-case (unchanged)
4. Generic camelCase humanizer (`_humanize_alert_type`) — any future unknown alert type at least renders something legible instead of blank

Purely additive: every alert type already covered by the SDK's `AllIssues` keeps its current title.

The override map is **load-bearing** until CE-206 ships. Once `gptDidYouMean` lands in `socketdev/core/issues.py` and the CLI's `socketdev` floor is bumped to include it, the override entry can be removed in a follow-up. The generic humanizer fallback stays as belt-and-suspenders for any future unknown alert types.

**Test plan:**
- `pytest tests/` — green; 8 new tests cover `gptDidYouMean`, an arbitrary unknown type, a regression guard for `licenseSpdxDisj`, and the humanizer helper (camelCase, PascalCase, single-word, empty input, acronym preservation). Original test count on author's machine at handoff time: 201 passed, 2 skipped (the two skips are pre-existing gitlab tests on `main`).
- Manual: rendered the console alert table against a synthesized `gptDidYouMean` alert; Alert column reads `"Possible typosquat attack (GPT)"` instead of blank.

## Public Changelog

<!-- changelog ⬇️-->
CLI now falls back to a humanized alert label for any alert type without an SDK-provided title, so the Alert column never renders blank. Adds an explicit label for `gptDidYouMean` ("Possible typosquat attack (GPT)") which previously rendered empty for customers on socketdev SDK versions without that alert class.
<!-- /changelog ⬆️ -->


<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->
