### PR TITLE
De-duplicate docker workflow pipelines

### DIFF
--- a/.github/actions/setup-docker-publish/action.yml
+++ b/.github/actions/setup-docker-publish/action.yml
@@ -1,0 +1,24 @@
+name: "Set up Docker publish"
+description: >-
+  Set up QEMU + Docker Buildx and authenticate to Docker Hub for multi-arch
+  image builds. Centralizes the QEMU/Buildx/login trio that the release,
+  preview, and stable workflows previously each copied (and which had drifted
+  to different pinned SHAs).
+
+inputs:
+  dockerhub-username:
+    description: "Docker Hub username (pass from secrets)"
+    required: true
+  dockerhub-token:
+    description: "Docker Hub token/password (pass from secrets)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+    - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+    - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}

--- a/.github/actions/setup-hatch/action.yml
+++ b/.github/actions/setup-hatch/action.yml
@@ -1,0 +1,13 @@
+name: "Set up Hatch build tooling"
+description: >-
+  Install the pinned hatch / hatchling / virtualenv toolchain used to build
+  and publish the package. Assumes Python is already set up by the caller.
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install "virtualenv<20.36"
+        pip install hatchling==1.27.0 hatch==1.14.0

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -28,23 +28,19 @@ jobs:
           fi
           echo "Version ${INPUT_VERSION} found on PyPI - proceeding with release"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Login to Docker Hub with Organization Token
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - name: Set up Docker publishing
+        uses: ./.github/actions/setup-docker-publish
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build & Push Stable Docker
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           push: true
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: socketdev/cli:stable
           build-args: |
             CLI_VERSION=${{ inputs.version }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -3,6 +3,12 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
 
+# Cancel an in-flight preview when the PR is pushed again -- previews are slow
+# (publish + multi-step Docker build), so superseded runs shouldn't keep going.
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   preview:
     # Skip on:
@@ -26,12 +32,8 @@ jobs:
         with:
           python-version: '3.13'
 
-      # Install all dependencies from pyproject.toml
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install "virtualenv<20.36"
-          pip install hatchling==1.27.0 hatch==1.14.0
+      - name: Install build tooling
+        uses: ./.github/actions/setup-hatch
 
       - name: Inject full dynamic version
         run: python .hooks/sync_version.py --dev
@@ -139,18 +141,12 @@ jobs:
           echo "success=false" >> $GITHUB_OUTPUT
           exit 1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
-
-      - name: Login to Docker Hub with Organization Token
+      - name: Set up Docker publishing
         if: steps.verify_package.outputs.success == 'true'
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: ./.github/actions/setup-docker-publish
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build & Push Docker Preview
         if: steps.verify_package.outputs.success == 'true'
@@ -159,7 +155,12 @@ jobs:
           VERSION: ${{ env.VERSION }}
         with:
           push: true
-          platforms: linux/amd64,linux/arm64
+          # Preview images are for quick testing -- build amd64 only. arm64 via
+          # QEMU emulation is the slowest part of the job; release builds keep
+          # multi-arch. GHA layer cache speeds up repeated preview builds.
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             socketdev/cli:pr-${{ github.event.pull_request.number }}
           build-args: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,9 @@ jobs:
         with:
           python-version: '3.13'
 
-      # Install all dependencies from pyproject.toml
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install "virtualenv<20.36"
-          pip install hatchling==1.27.0 hatch==1.14.0
-          
+      - name: Install build tooling
+        uses: ./.github/actions/setup-hatch
+
       - name: Get Version
         id: version
         env:
@@ -72,17 +68,11 @@ jobs:
         if: steps.version_check.outputs.pypi_exists != 'true'
         uses: pypa/gh-action-pypi-publish@ab69e431e9c9f48a3310be0a56527c679f56e04d
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
-
-      - name: Login to Docker Hub with Organization Token
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+      - name: Set up Docker publishing
+        uses: ./.github/actions/setup-docker-publish
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Verify package is installable
         id: verify_package
@@ -112,6 +102,8 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             socketdev/cli:latest
             socketdev/cli:${{ env.VERSION }}


### PR DESCRIPTION
## Summary

Speeds up and de-duplicates the Docker publish pipelines (release / PR preview / stable). No change to *what* gets published — only how the workflows are assembled and how fast they run.

> **Stacked on #217.** Base is `lelia/fix-dependabot-checks` to avoid a `pr-preview.yml` conflict with that PR's Dependabot skip. GitHub auto-retargets this to `main` when #217 merges.

## Speed (PR preview — the iterative path)

- **Concurrency cancel-in-progress** — pushing a PR again now cancels the superseded preview run instead of letting the slow build churn. (`python-tests`/`dependabot-review` already had this; preview didn't.)
- **amd64-only preview images** — arm64 under QEMU emulation was the slowest part of the job, and a preview image is just for quick testing. Release & stable keep multi-arch.
- **GHA Docker layer cache** (`type=gha`) on all image builds — unchanged layers are reused across runs.

## De-duplication (composite actions)

GitHub Actions doesn't support YAML anchors, so the idiomatic fix is local composite actions:

- **`.github/actions/setup-docker-publish`** — the QEMU + Buildx + Docker Hub login trio, previously copied into all three Docker workflows. They had **drifted to three different pinned SHA sets**; now there's one. (Docker Hub creds passed as inputs, since composite actions can't read `secrets.*` directly.)
- **`.github/actions/setup-hatch`** — the pinned `virtualenv`/`hatchling`/`hatch` install shared by `release.yml` and `pr-preview.yml`.

## Test plan

- [x] All five touched/new files parse as valid YAML
- [x] QEMU/Buildx/login now appear only in the composite (0 refs left in workflows)
- [ ] A preview run completes faster (amd64-only + cache) and gets cancelled when the PR is pushed again
- [ ] A release dry-run still produces multi-arch images
- [ ] Docker layer cache (`type=gha`) populates without permission errors

## Notes / possible follow-ups

- `docker-stable.yml` still pins `actions/checkout` + `build-push-action` to different SHAs than the other workflows. Left as-is — Dependabot's grouped `github-actions` updates will reconcile these going forward.
- The Test PyPI "verify package available" polling loop (up to ~10 min) is untouched here; a future change could build the preview image from the locally-built wheel to skip the Test PyPI round-trip entirely.
