### PR TITLE
Bump required SDK version to `>=3.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.4.1
+
+### Changed: Bump required SDK version to `>=3.2.0`
+
+- Picks up `socketdev 3.2.0`, which adds `OTHER = "other"` to `SocketCategory`
+  so the backend's `other` alert category no longer trips the
+  "Unknown SocketCategory" warning fallback (SDK PR #85).
+- No CLI logic changes.
+
 ## 2.4.0
 
 ### Changed: license details are no longer requested on the full-scan diff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.4.0"
+version = "2.4.1"
 requires-python = ">= 3.11"
 license = {"file" = "LICENSE"}
 dependencies = [
@@ -16,7 +16,7 @@ dependencies = [
     'GitPython',
     'packaging',
     'python-dotenv',
-    "socketdev>=3.1.2,<4.0.0",
+    "socketdev>=3.2.0,<4.0.0",
     "bs4>=0.0.2",
     "markdown>=3.10",
     "brotli>=1.0.9; platform_python_implementation == 'CPython'",

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.4.0'
+__version__ = '2.4.1'
 USER_AGENT = f'SocketPythonCLI/{__version__}'

--- a/uv.lock
+++ b/uv.lock
@@ -1257,20 +1257,20 @@ wheels = [
 
 [[package]]
 name = "socketdev"
-version = "3.1.2"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/3c/974f11a7064d12303049ed46b2a475ff6e65c073c0985558195756d30543/socketdev-3.1.2.tar.gz", hash = "sha256:3dc46258f29f66f8ed84767ab6158237d38a7de4ecb4b28950b4f0bb0d49ff68", size = 178479, upload-time = "2026-06-02T23:33:17.251Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/05/0748d1a357a743f968475aecfad4d53ce109ae65fc418d177faecbb25754/socketdev-3.2.0.tar.gz", hash = "sha256:d8743e1a83135f17e8713539c656b4847ada1450315b05e48ec8df1ed984c307", size = 178440, upload-time = "2026-06-03T02:47:26.696Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e9/72a8ccf2c3a20d436616e303b3c51a700e0def781806d361bd0f65ab436b/socketdev-3.1.2-py3-none-any.whl", hash = "sha256:14a4e913fa5c2bbea856820b2ebc9f7c21960c8c42e77a8fd2ae4ef626ba0f49", size = 67225, upload-time = "2026-06-02T23:33:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b5/6a3b2bcec759d5d306f416e1b167b985f44f89e990afcd25569a2e591ffd/socketdev-3.2.0-py3-none-any.whl", hash = "sha256:e4b97bdc22ec8e12899f218c8089eaa8e9696f7556930e13f05996ad210718af", size = 67267, upload-time = "2026-06-03T02:47:24.76Z" },
 ]
 
 [[package]]
 name = "socketsecurity"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
@@ -1327,7 +1327,7 @@ requires-dist = [
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
-    { name = "socketdev", specifier = ">=3.1.2,<4.0.0" },
+    { name = "socketdev", specifier = ">=3.2.0,<4.0.0" },
     { name = "twine", marker = "extra == 'dev'" },
     { name = "uv", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]


### PR DESCRIPTION
## Summary

Bumps the `socketdev` dependency floor from `>=3.0.33` to `>=3.2.0` so the CLI picks up the [new SDK release](https://github.com/SocketDev/socket-sdk-python/releases/tag/v3.2.0) that adds `OTHER = "other"` to `SocketCategory` (https://github.com/SocketDev/socket-sdk-python/releases/tag/v3.2.0).

## Why

The Socket backend returns `"other"` as an alert category. Today the SDK tolerates it via a `try/except` fallback but logs a confusing `"Unknown SocketCategory 'other'; falling back to MISCELLANEOUS"` warning, which customers could misinterpret as a crash. SDK v3.2.0 recognizes `"other"` as a first-class category, silencing the warning.

## Changes

- `pyproject.toml` — `socketdev>=3.2.0,<4.0.0`
- CLI version `2.3.1` → `2.4.4`

Refs: CE-225