### PR TITLE
Bundle pyenv in the Docker image for on-demand Python versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.4.1
+
+### Added: pyenv in the Docker image
+
+- The `socketdev/cli` Docker image now bundles [pyenv](https://github.com/pyenv/pyenv)
+  (pinned to `v2.7.1`) along with the Alpine build dependencies needed to compile
+  CPython from source, so the image can build/install arbitrary Python versions on
+  demand.
+- The CLI itself is unchanged — this release only affects the published Docker image.
+
 ## 2.4.0
 
 ### Changed: license details are no longer requested on the full-scan diff

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,29 @@ ENV GOPATH="/go"
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
+# Install pyenv
+# pyenv lets us build/install arbitrary Python versions on demand. We install
+# the build dependencies needed to compile CPython on Alpine, then install
+# pyenv itself. We deliberately only symlink the `pyenv` binary onto the PATH
+# and do NOT add pyenv's shims directory, so its shims don't shadow the system
+# Python that the CLI runs on.
+RUN apk add --no-cache \
+        bash \
+        bzip2-dev \
+        ca-certificates \
+        libffi-dev \
+        libxslt-dev \
+        linux-headers \
+        ncurses-dev \
+        openssl-dev \
+        readline-dev \
+        sqlite-dev \
+        xz-dev \
+        zlib-dev
+RUN curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | PYENV_GIT_TAG="v2.7.1" bash && \
+    ln -s ~/.pyenv/bin/pyenv /bin/pyenv && \
+    pyenv --version
+
 # Install CLI based on build mode
 RUN if [ "$USE_LOCAL_INSTALL" = "true" ]; then \
         echo "Using local development install"; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.4.0"
+version = "2.4.1"
 requires-python = ">= 3.11"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.4.0'
+__version__ = '2.4.1'
 USER_AGENT = f'SocketPythonCLI/{__version__}'

--- a/uv.lock
+++ b/uv.lock
@@ -1270,7 +1270,7 @@ wheels = [
 
 [[package]]
 name = "socketsecurity"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "brotli", marker = "platform_python_implementation == 'CPython'" },


### PR DESCRIPTION
Adds [pyenv](https://github.com/pyenv/pyenv) to the `socketdev/cli` Docker image (just below the `uv` install), so the image can build and install arbitrary Python versions on demand. Tracked in [ENG-5094](https://linear.app/socketdev/issue/ENG-5094).

### What changed
- Install pyenv, pinned to `v2.7.1` (latest stable; the coana reference used the older `v2.6.20`), via the pyenv-installer.
- Add the Alpine build dependencies needed to compile CPython from source (`bash` + `bzip2-dev`, `libffi-dev`, `libxslt-dev`, `linux-headers`, `ncurses-dev`, `openssl-dev`, `readline-dev`, `sqlite-dev`, `xz-dev`, `zlib-dev`). `bash` is required because pyenv and the pyenv-installer are bash scripts.
- Only the `pyenv` binary is symlinked onto the `PATH`; pyenv's **shims directory is intentionally omitted**, so its shims don't shadow the system Python the CLI runs on.
- Bump version `2.4.0` -> `2.4.1` (+ `uv.lock`, CHANGELOG) so this ships in a published image. No CLI code changes.

### Verification
Built the image locally (`scripts/build_container.sh pypi-build=local stable=false`) and replayed every pyenv action the coana CLI invokes (`python-versions-manager.ts`) inside the container:
- `which pyenv`, `pyenv global` (`system`), `pyenv install --list` (241 versions), `pyenv versions --bare`, `pyenv prefix` — all succeed.
- `pyenv install --skip-existing 3.11.14` compiles CPython in ~1m18s with no missing-module warnings; the built interpreter runs and imports every stdlib module backed by the added build deps (`ssl, ctypes, lzma, bz2, sqlite3, readline, zlib, curses`).
- Confirmed `python3` still resolves to the system `/usr/local/bin/python3` (3.14.5) and `.pyenv/shims` is not on `PATH`.

## Public Changelog

<!-- changelog ⬇️-->
The `socketdev/cli` Docker image now bundles pyenv (v2.7.1) with the build dependencies needed to compile CPython, allowing it to install arbitrary Python versions on demand.
<!-- /changelog ⬆️ -->

<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-improvement -->
