### PR TITLE
docs: correct remaining reachability CLI reference gaps (v2.4.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.4.6
+
+### Docs: reachability reference corrections
+
+- Documented the `uv` and Enterprise-plan prerequisites the CLI enforces **before** running
+  reachability (exit code 3 if unmet), and clarified that per-ecosystem build toolchains
+  (JDK / .NET / Go / a compatible Python interpreter) are checked by the analysis engine at
+  runtime, not pre-checked by the CLI.
+- Corrected the `--reach-min-severity` values to `info, low, moderate, high, critical`.
+- Documented the previously-undocumented reachability flags: `--reach-enable-analysis-splitting`,
+  `--reach-detailed-analysis-log-file`, `--reach-lazy-mode`, and `--reach-use-only-pregenerated-sboms`.
+- Clarified that `--only-facts-file` submits only the facts file when **creating** the full scan
+  (it does not require a pre-existing scan).
+- Documentation-only; no functional code changes.
+
 ## 2.4.5
 
 ### Changed: Bump required SDK version to `>=3.2.1`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -154,7 +154,8 @@ socketcli [-h] [--api-token API_TOKEN] [--repo REPO] [--workspace WORKSPACE] [--
           [--ignore-commit-files] [--disable-blocking] [--disable-ignore] [--enable-diff] [--scm SCM] [--timeout TIMEOUT] [--include-module-folders]
           [--reach] [--reach-version REACH_VERSION] [--reach-analysis-timeout REACH_ANALYSIS_TIMEOUT]
           [--reach-analysis-memory-limit REACH_ANALYSIS_MEMORY_LIMIT] [--reach-concurrency REACH_CONCURRENCY] [--reach-ecosystems REACH_ECOSYSTEMS]
-          [--reach-min-severity {low,medium,high,critical}] [--reach-skip-cache] [--reach-disable-analytics] [--reach-debug] [--reach-disable-external-tool-checks]
+          [--reach-min-severity <level>] [--reach-skip-cache] [--reach-disable-analytics] [--reach-enable-analysis-splitting] [--reach-detailed-analysis-log-file]
+          [--reach-lazy-mode] [--reach-use-only-pregenerated-sboms] [--reach-debug] [--reach-disable-external-tool-checks]
           [--reach-output-file REACH_OUTPUT_FILE] [--only-facts-file] [--version]
 ````
 
@@ -238,25 +239,35 @@ If you don't want to provide the Socket API Token every time then you can use th
 #### Reachability Analysis
 | Parameter                        | Required | Default | Description                                                                                                                |
 |:---------------------------------|:---------|:--------|:---------------------------------------------------------------------------------------------------------------------------|
-| `--reach`                          | False    | False   | Enable reachability analysis to identify which vulnerable functions are actually called by your code                       |
+| `--reach`                          | False    | False   | Enable reachability analysis to identify which vulnerable functions are actually called by your code. Creates a tier-1 full-application reachability scan (`scan_type=socket_tier1`). |
 | `--reach-version`                  | False    | latest  | Version of @coana-tech/cli to use for analysis                                                                             |
 | `--reach-analysis-timeout`         | False    | *coana* | Timeout in seconds for the reachability analysis. Omitted by default, so coana applies its own (currently 600s). Alias: `--reach-timeout` |
 | `--reach-analysis-memory-limit`    | False    | *coana* | Memory limit in MB for the reachability analysis. Omitted by default, so coana applies its own (currently 8192). Alias: `--reach-memory-limit` |
 | `--reach-concurrency`              | False    | *coana* | Control parallel analysis execution (must be >= 1). Omitted by default, so coana applies its own (currently 1)             |
 | `--reach-additional-params`        | False    |         | Pass custom parameters to the coana CLI tool                                                                               |
 | `--reach-ecosystems`               | False    |         | Comma-separated list of ecosystems to analyze (e.g., "npm,pypi"). If not specified, all supported ecosystems are analyzed  |
-| `--reach-min-severity`             | False    |         | Minimum severity level for reporting reachability results (low, medium, high, critical)                                    |
+| `--reach-min-severity`             | False    |         | Minimum severity level for reporting reachability results (info, low, moderate, high, critical)                            |
 | `--reach-skip-cache`               | False    | False   | Skip cache and force fresh reachability analysis                                                                           |
 | `--reach-disable-analytics`        | False    | False   | Disable analytics collection during reachability analysis                                                                  |
+| `--reach-enable-analysis-splitting` | False   | False   | Enable analysis splitting/bucketing (a legacy performance feature). Splitting is disabled by default.                      |
+| `--reach-detailed-analysis-log-file` | False  | False   | Write a detailed analysis log file; its path is printed to stdout                                                          |
+| `--reach-lazy-mode`                | False    | False   | Enable lazy mode (experimental performance feature)                                                                        |
+| `--reach-use-only-pregenerated-sboms` | False | False   | Build the scan only from pre-generated CycloneDX (CDX) and SPDX files in your project (requires --reach)                    |
 | `--reach-debug`                    | False    | False   | Enable coana debug output (`--debug`) for the analysis, independent of the global `--enable-debug`                         |
 | `--reach-disable-external-tool-checks` | False | False | Disable coana's external tool availability checks (passes `--disable-external-tool-checks`)                              |
 | `--reach-output-file`              | False    | .socket.facts.json | Path where reachability analysis results should be saved                                                        |
 | `--reach-exclude-paths`            | False    |         | **[DEPRECATED — use `--exclude-paths`]** Comma-separated paths to exclude from reachability analysis. Still honored (unioned with `--exclude-paths`) but will be hidden in a future release |
-| `--only-facts-file`                | False    | False   | Submit only the .socket.facts.json file to an existing scan (requires --reach and a prior scan)                            |
+| `--only-facts-file`                | False    | False   | Submit only the .socket.facts.json file when creating the full scan (requires --reach)                                     |
 
 **Reachability Analysis Requirements:**
-- `npm` - Required to install and run @coana-tech/cli
-- `npx` - Required to execute @coana-tech/cli
+
+The Python CLI verifies the following **up front** (before invoking the analysis engine) and exits with code **3** if any are unmet:
+- `npm` - Required to install and run `@coana-tech/cli` (the analysis engine)
+- `npx` - Required to execute `@coana-tech/cli`
+- `uv` - Required by the analysis engine
+- An **Enterprise** Socket organization plan (any `enterprise*` plan, including Enterprise trials)
+
+Separately, the analysis engine (coana) needs the **per-ecosystem build toolchain** for whatever languages your project uses — e.g. a compatible Python interpreter (3.11+, or PyPy) for Python, a JDK for Java/Kotlin/Scala, .NET 6+ for C#, the matching Go toolchain for Go, etc. These are validated by the engine **at analysis time** (the CLI does not pre-check them) and that validation can be skipped with `--reach-disable-external-tool-checks`.
 
 ## Config file support
 
@@ -302,7 +313,7 @@ Sample config files:
 
 For CI-specific examples and guidance, see [`ci-cd.md`](ci-cd.md).
 
-The CLI will automatically install `@coana-tech/cli` if not present. Use `--reach` to enable reachability analysis during a full scan, or use `--only-facts-file` with `--reach` to submit reachability results to an existing scan.
+The CLI will automatically install `@coana-tech/cli` if not present. Use `--reach` to enable reachability analysis during a full scan, or add `--only-facts-file` (with `--reach`) to submit only the reachability facts file (`.socket.facts.json`) when creating the full scan.
 
 #### Advanced Configuration
 | Parameter                | Required | Default | Description                                                           |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.4.5"
+version = "2.4.6"
 requires-python = ">= 3.11"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.4.5'
+__version__ = '2.4.6'
 USER_AGENT = f'SocketPythonCLI/{__version__}'

--- a/uv.lock
+++ b/uv.lock
@@ -1283,7 +1283,7 @@ wheels = [
 
 [[package]]
 name = "socketsecurity"
-version = "2.4.5"
+version = "2.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "brotli", marker = "platform_python_implementation == 'CPython'" },


### PR DESCRIPTION
## What

Layers the remaining Python CLI reachability **reference** corrections onto current `main` (v2.4.5 → **2.4.6**), bringing the reachability documentation in line with the current implementation. Keeps the stable `#reachability-analysis` anchor in `docs/cli-reference.md`.

The headline reachability flag work already landed on `main` separately — **#226** (canonical `--reach-analysis-timeout` / `--reach-analysis-memory-limit` names, coana-delegated defaults) and **#227** (unified `--exclude-paths`, deprecate `--reach-exclude-paths`). This PR fixes only what those left stale or missing in `docs/cli-reference.md`.

## Changes (`docs/cli-reference.md`)

1. **Requirements** — document the `uv` + **Enterprise-plan** prerequisites the CLI enforces *before* running reachability (exits with code 3 if unmet), and clarify that per-ecosystem build toolchains (JDK / .NET / Go / a compatible Python interpreter) are checked by the analysis engine at runtime, not pre-checked by the CLI.
2. **`--reach-min-severity`** — corrected the documented values to `info, low, moderate, high, critical` (was the inaccurate `low, medium, high, critical`).
3. Documented 4 previously-undocumented flags: `--reach-enable-analysis-splitting`, `--reach-detailed-analysis-log-file`, `--reach-lazy-mode`, `--reach-use-only-pregenerated-sboms`.
4. **`--only-facts-file`** — fixed misleading wording (submits only the facts file when *creating* the full scan; no pre-existing scan required).
5. **`--reach`** — noted it creates a tier-1 full-application scan (`scan_type=socket_tier1`).

## Other files (tooling churn, no code changes)

- `CHANGELOG.md` — `2.4.6` entry (docs-only).
- `socketsecurity/__init__.py`, `pyproject.toml`, `uv.lock` — patch bump `2.4.5 → 2.4.6`, mandated by the repo's `sync-version` pre-commit hook (every commit forces a patch bump + lockfile refresh).

## Notes

- **Draft** intentionally — held for batched review/merge.
- Python⇄Node reachability parity reconciled with the Node CLI maintainer; path-exclusion is now converged (`--exclude-paths` in both CLIs).