### PR TITLE
Retry transient full-scan upload failures (502/503/504/408, dropped connections)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@
   jitter). Such failures are intermittent and a retried upload almost always succeeds.
   In these failure modes the server never finished reading the request body, so no scan
   was created and a retry does not duplicate one; in the rare case where a gateway
-  timeout races a request the server later
-  completes, the extra scan is benign and superseded by the retried one (as if the CLI had
-  run twice).
+  timeout races a request the server later completes, the extra scan is benign and
+  superseded by the retried one (as if the CLI had run twice).
   Non-transient errors (400/401/403/404/429 and error payloads) are never retried. Each
   retry logs a warning explaining what failed and when the next attempt happens.
+- Requires `socketdev>=3.3.0`: the SDK now records the HTTP status code on the exceptions
+  it raises and owns the transient-vs-deterministic classification
+  (`APIFailure.is_transient_error()`), so the CLI no longer parses status codes out of
+  exception message text.
 
 ## 2.4.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2.4.8
+
+### Fixed: retry transient full-scan upload failures
+
+- The full-scan upload (`POST /orgs/<org>/full-scans`) now retries transient
+  gateway/connection failures — HTTP 502/503/504/408, dropped or reset connections, and
+  request timeouts — up to 3 total attempts with increasing waits (~10s, then ~30s, plus
+  jitter). Such failures are intermittent and a retried upload almost always succeeds.
+  In these failure modes the server never finished reading the request body, so no scan
+  was created and a retry does not duplicate one; in the rare case where a gateway
+  timeout races a request the server later
+  completes, the extra scan is benign and superseded by the retried one (as if the CLI had
+  run twice).
+  Non-transient errors (400/401/403/404/429 and error payloads) are never retried. Each
+  retry logs a warning explaining what failed and when the next attempt happens.
+
 ## 2.4.7
 
 ### Changed: pin @coana-tech/cli version; auto-update is now opt-in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.4.7"
+version = "2.4.8"
 requires-python = ">= 3.11"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     'GitPython',
     'packaging',
     'python-dotenv',
-    "socketdev>=3.2.1,<4.0.0",
+    "socketdev>=3.3.0,<4.0.0",
     "bs4>=0.0.2",
     "markdown>=3.10",
     "brotli>=1.0.9; platform_python_implementation == 'CPython'",

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.4.7'
+__version__ = '2.4.8'
 USER_AGENT = f'SocketPythonCLI/{__version__}'

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -84,11 +84,10 @@ TIER1_FINALIZE_BACKOFF_SECONDS = 1.0
 
 # Full scan upload retry policy. An upload can fail transiently at the gateway/connection
 # level (an HTTP 502/503/504/408, a dropped or reset connection, or a client-side timeout)
-# without the server having created the scan; a retried upload almost always succeeds.
-# In these failure modes no scan was created, so a retry does not duplicate one. (A
-# duplicate is possible only if a gateway timeout races a request the server later
-# completes; that is benign - the retried scan supersedes the orphaned one, same as
-# running the CLI twice.)
+# without the server having created the scan. In these failure modes no scan was created,
+# so a retry does not duplicate one. (A duplicate is possible only if a gateway timeout
+# races a request the server later completes; that is benign - the retried scan supersedes
+# the orphaned one, same as running the CLI twice.)
 FULL_SCAN_UPLOAD_MAX_ATTEMPTS = 3
 # Wait before retry attempt 2 and attempt 3 respectively (plus a little jitter so a fleet of
 # CI jobs hitting the same failure doesn't retry in lock-step).
@@ -836,8 +835,7 @@ class Core:
         upload_files, compressed_temp_files = self._compress_facts_files_for_upload(files)
         try:
             # Retry transient gateway/timeout failures (502/503/504/408, dropped connections,
-            # timeouts) with increasing waits; such failures are intermittent and a retried
-            # upload almost always succeeds. In these failure modes the server never finished
+            # timeouts) with increasing waits. In these failure modes the server never finished
             # reading the request body, so no scan was created and a retry does not duplicate
             # one (see the retry-policy comment above FULL_SCAN_UPLOAD_MAX_ATTEMPTS). fullscans.post()
             # rebuilds its lazy file loaders from the plain paths in upload_files on every call,

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import random
 import re
 import sys
 import tarfile
@@ -13,7 +14,12 @@ from typing import Dict, List, Tuple, Set, TYPE_CHECKING, Optional
 if TYPE_CHECKING:
     from socketsecurity.config import CliConfig
 from socketdev import socketdev
-from socketdev.exceptions import APIFailure
+from socketdev.exceptions import (
+    APIBadGateway,
+    APIConnectionError,
+    APIFailure,
+    APITimeout,
+)
 from socketdev.fullscans import FullScanParams, SocketArtifact
 from socketdev.org import Organization
 from socketdev.repos import RepositoryInfo
@@ -75,6 +81,48 @@ SOCKET_FACTS_BROTLI_CHUNK_SIZE = 1024 * 1024
 # full scan and can fail transiently (network/API blips); a few backoff retries make it robust.
 TIER1_FINALIZE_MAX_ATTEMPTS = 3
 TIER1_FINALIZE_BACKOFF_SECONDS = 1.0
+
+# Full scan upload retry policy. An upload can fail transiently at the gateway/connection
+# level (an HTTP 502/503/504/408, a dropped or reset connection, or a client-side timeout)
+# without the server having created the scan; a retried upload almost always succeeds.
+# In these failure modes no scan was created, so a retry does not duplicate one. (A
+# duplicate is possible only if a gateway timeout races a request the server later
+# completes; that is benign - the retried scan supersedes the orphaned one, same as
+# running the CLI twice.)
+FULL_SCAN_UPLOAD_MAX_ATTEMPTS = 3
+# Wait before retry attempt 2 and attempt 3 respectively (plus a little jitter so a fleet of
+# CI jobs hitting the same failure doesn't retry in lock-step).
+FULL_SCAN_UPLOAD_BACKOFF_SCHEDULE_SECONDS = (10.0, 30.0)
+FULL_SCAN_UPLOAD_BACKOFF_JITTER_SECONDS = 2.0
+# Transient gateway/timeout HTTP statuses that the SDK does NOT raise as a dedicated
+# exception class (502 has APIBadGateway; 408/503/504 surface as the catch-all APIFailure
+# with the status only present in the message text - see _is_transient_full_scan_upload_error).
+FULL_SCAN_UPLOAD_RETRYABLE_STATUS_CODES = frozenset({408, 503, 504})
+# Matches the status code the SDK embeds in catch-all APIFailure messages
+# (socketdev/core/api.py: "Bad Request: HTTP original_status_code:<code> ...").
+_API_FAILURE_STATUS_CODE_RE = re.compile(r"original_status_code:(\d{3})")
+
+
+def _is_transient_full_scan_upload_error(error: Exception) -> bool:
+    """Whether a full-scan upload failure is transient and safe to retry.
+
+    Transient means the failure happened at the gateway/connection level, normally before the
+    server finished reading the request body (so no scan was created server-side): HTTP
+    502/503/504/408, client-side timeouts, and dropped/reset connections. 4xx client errors
+    (400/401/403/404/429) and success responses carrying an error payload are never retried.
+    """
+    if isinstance(error, (APIBadGateway, APIConnectionError, APITimeout)):
+        # 502 / connection reset-dropped / request timeout - the SDK raises dedicated classes.
+        return True
+    if type(error) is APIFailure:
+        # The SDK raises 408/503/504 (and every other status without a dedicated class,
+        # including 400) as the catch-all APIFailure, so match on the exact class plus the
+        # status code embedded in the message. Subclasses (APIAccessDenied, APIResourceNotFound,
+        # APIInsufficientQuota, ...) are deliberately excluded - those are never transient.
+        match = _API_FAILURE_STATUS_CODE_RE.search(str(error))
+        if match:
+            return int(match.group(1)) in FULL_SCAN_UPLOAD_RETRYABLE_STATUS_CODES
+    return False
 
 
 def _humanize_alert_type(alert_type: str) -> str:
@@ -787,7 +835,34 @@ class Core:
         # facts file under the per-file upload size cap. See _compress_facts_files_for_upload.
         upload_files, compressed_temp_files = self._compress_facts_files_for_upload(files)
         try:
-            res = self.sdk.fullscans.post(upload_files, params, use_types=True, use_lazy_loading=True, max_open_files=50, base_paths=base_paths)
+            # Retry transient gateway/timeout failures (502/503/504/408, dropped connections,
+            # timeouts) with increasing waits; such failures are intermittent and a retried
+            # upload almost always succeeds. In these failure modes the server never finished
+            # reading the request body, so no scan was created and a retry does not duplicate
+            # one (see the retry-policy comment above FULL_SCAN_UPLOAD_MAX_ATTEMPTS). fullscans.post()
+            # rebuilds its lazy file loaders from the plain paths in upload_files on every call,
+            # so simply calling it again per attempt is safe. The loop must stay inside this try
+            # so the temp .br files (cleaned up in the finally below) outlive every attempt.
+            for attempt in range(1, FULL_SCAN_UPLOAD_MAX_ATTEMPTS + 1):
+                try:
+                    res = self.sdk.fullscans.post(upload_files, params, use_types=True, use_lazy_loading=True, max_open_files=50, base_paths=base_paths)
+                    break
+                except APIFailure as error:
+                    if attempt >= FULL_SCAN_UPLOAD_MAX_ATTEMPTS or not _is_transient_full_scan_upload_error(error):
+                        raise
+                    backoff_index = min(attempt, len(FULL_SCAN_UPLOAD_BACKOFF_SCHEDULE_SECONDS)) - 1
+                    wait_seconds = FULL_SCAN_UPLOAD_BACKOFF_SCHEDULE_SECONDS[backoff_index] + random.uniform(
+                        0, FULL_SCAN_UPLOAD_BACKOFF_JITTER_SECONDS
+                    )
+                    # SDK error messages can span many lines (path + response headers); the
+                    # first line carries the status, which is all the warning needs.
+                    error_summary = str(error).strip().splitlines()[0] if str(error).strip() else ""
+                    log.warning(
+                        f"Full scan upload failed with {type(error).__name__}({error_summary}), "
+                        f"retrying in {wait_seconds:.0f}s "
+                        f"(attempt {attempt + 1}/{FULL_SCAN_UPLOAD_MAX_ATTEMPTS})"
+                    )
+                    time.sleep(wait_seconds)
         finally:
             for temp_file in compressed_temp_files:
                 try:

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -14,12 +14,7 @@ from typing import Dict, List, Tuple, Set, TYPE_CHECKING, Optional
 if TYPE_CHECKING:
     from socketsecurity.config import CliConfig
 from socketdev import socketdev
-from socketdev.exceptions import (
-    APIBadGateway,
-    APIConnectionError,
-    APIFailure,
-    APITimeout,
-)
+from socketdev.exceptions import APIFailure
 from socketdev.fullscans import FullScanParams, SocketArtifact
 from socketdev.org import Organization
 from socketdev.repos import RepositoryInfo
@@ -84,44 +79,18 @@ TIER1_FINALIZE_BACKOFF_SECONDS = 1.0
 
 # Full scan upload retry policy. An upload can fail transiently at the gateway/connection
 # level (an HTTP 502/503/504/408, a dropped or reset connection, or a client-side timeout)
-# without the server having created the scan. In these failure modes no scan was created,
-# so a retry does not duplicate one. (A duplicate is possible only if a gateway timeout
-# races a request the server later completes; that is benign - the retried scan supersedes
-# the orphaned one, same as running the CLI twice.)
-FULL_SCAN_UPLOAD_MAX_ATTEMPTS = 3
-# Wait before retry attempt 2 and attempt 3 respectively (plus a little jitter so a fleet of
-# CI jobs hitting the same failure doesn't retry in lock-step).
-FULL_SCAN_UPLOAD_BACKOFF_SCHEDULE_SECONDS = (10.0, 30.0)
+# without the server having created the scan; the SDK classifies those failures via
+# APIFailure.is_transient_error() (socketdev>=3.3.0). In these failure modes no scan was
+# created, so a retry does not duplicate one. (A duplicate is possible only if a gateway
+# timeout races a request the server later completes; that is benign - the retried scan
+# supersedes the orphaned one, same as running the CLI twice.)
+#
+# Each schedule entry is the wait before the next attempt once the current one fails (plus
+# a little jitter so a fleet of CI jobs hitting the same failure doesn't retry in
+# lock-step); the final None means the last attempt's failure is re-raised, not retried.
+FULL_SCAN_UPLOAD_BACKOFF_SCHEDULE_SECONDS = (10.0, 30.0, None)
+FULL_SCAN_UPLOAD_MAX_ATTEMPTS = len(FULL_SCAN_UPLOAD_BACKOFF_SCHEDULE_SECONDS)
 FULL_SCAN_UPLOAD_BACKOFF_JITTER_SECONDS = 2.0
-# Transient gateway/timeout HTTP statuses that the SDK does NOT raise as a dedicated
-# exception class (502 has APIBadGateway; 408/503/504 surface as the catch-all APIFailure
-# with the status only present in the message text - see _is_transient_full_scan_upload_error).
-FULL_SCAN_UPLOAD_RETRYABLE_STATUS_CODES = frozenset({408, 503, 504})
-# Matches the status code the SDK embeds in catch-all APIFailure messages
-# (socketdev/core/api.py: "Bad Request: HTTP original_status_code:<code> ...").
-_API_FAILURE_STATUS_CODE_RE = re.compile(r"original_status_code:(\d{3})")
-
-
-def _is_transient_full_scan_upload_error(error: Exception) -> bool:
-    """Whether a full-scan upload failure is transient and safe to retry.
-
-    Transient means the failure happened at the gateway/connection level, normally before the
-    server finished reading the request body (so no scan was created server-side): HTTP
-    502/503/504/408, client-side timeouts, and dropped/reset connections. 4xx client errors
-    (400/401/403/404/429) and success responses carrying an error payload are never retried.
-    """
-    if isinstance(error, (APIBadGateway, APIConnectionError, APITimeout)):
-        # 502 / connection reset-dropped / request timeout - the SDK raises dedicated classes.
-        return True
-    if type(error) is APIFailure:
-        # The SDK raises 408/503/504 (and every other status without a dedicated class,
-        # including 400) as the catch-all APIFailure, so match on the exact class plus the
-        # status code embedded in the message. Subclasses (APIAccessDenied, APIResourceNotFound,
-        # APIInsufficientQuota, ...) are deliberately excluded - those are never transient.
-        match = _API_FAILURE_STATUS_CODE_RE.search(str(error))
-        if match:
-            return int(match.group(1)) in FULL_SCAN_UPLOAD_RETRYABLE_STATUS_CODES
-    return False
 
 
 def _humanize_alert_type(alert_type: str) -> str:
@@ -837,19 +806,19 @@ class Core:
             # Retry transient gateway/timeout failures (502/503/504/408, dropped connections,
             # timeouts) with increasing waits. In these failure modes the server never finished
             # reading the request body, so no scan was created and a retry does not duplicate
-            # one (see the retry-policy comment above FULL_SCAN_UPLOAD_MAX_ATTEMPTS). fullscans.post()
-            # rebuilds its lazy file loaders from the plain paths in upload_files on every call,
-            # so simply calling it again per attempt is safe. The loop must stay inside this try
-            # so the temp .br files (cleaned up in the finally below) outlive every attempt.
-            for attempt in range(1, FULL_SCAN_UPLOAD_MAX_ATTEMPTS + 1):
+            # one (see the retry-policy comment above FULL_SCAN_UPLOAD_BACKOFF_SCHEDULE_SECONDS).
+            # fullscans.post() rebuilds its lazy file loaders from the plain paths in
+            # upload_files on every call, so simply calling it again per attempt is safe. The
+            # loop must stay inside this try so the temp .br files (cleaned up in the finally
+            # below) outlive every attempt.
+            for attempt, backoff_seconds in enumerate(FULL_SCAN_UPLOAD_BACKOFF_SCHEDULE_SECONDS, start=1):
                 try:
                     res = self.sdk.fullscans.post(upload_files, params, use_types=True, use_lazy_loading=True, max_open_files=50, base_paths=base_paths)
                     break
                 except APIFailure as error:
-                    if attempt >= FULL_SCAN_UPLOAD_MAX_ATTEMPTS or not _is_transient_full_scan_upload_error(error):
+                    if backoff_seconds is None or not error.is_transient_error():
                         raise
-                    backoff_index = min(attempt, len(FULL_SCAN_UPLOAD_BACKOFF_SCHEDULE_SECONDS)) - 1
-                    wait_seconds = FULL_SCAN_UPLOAD_BACKOFF_SCHEDULE_SECONDS[backoff_index] + random.uniform(
+                    wait_seconds = backoff_seconds + random.uniform(
                         0, FULL_SCAN_UPLOAD_BACKOFF_JITTER_SECONDS
                     )
                     # SDK error messages can span many lines (path + response headers); the

--- a/tests/unit/test_full_scan_retry.py
+++ b/tests/unit/test_full_scan_retry.py
@@ -2,9 +2,10 @@
 
 A `POST /orgs/<org>/full-scans` upload can fail transiently (an HTTP 502/503/504/408, a
 dropped or reset connection, or a timeout) without the server having created the scan.
-`Core.create_full_scan` retries those transient failures; these tests cover the retry
-classification, the loop bounds, and that the temporary brotli-compressed facts files
-survive until every attempt has finished.
+`Core.create_full_scan` retries the failures the SDK classifies as transient
+(`APIFailure.is_transient_error()`, socketdev>=3.3.0); these tests cover the retry
+decision, the loop bounds, and that the temporary brotli-compressed facts files survive
+until every attempt has finished.
 """
 
 import logging
@@ -26,7 +27,6 @@ from socketsecurity.core import (
     SOCKET_FACTS_BROTLI_FILENAME,
     SOCKET_FACTS_FILENAME,
     Core,
-    _is_transient_full_scan_upload_error,
 )
 
 
@@ -46,13 +46,14 @@ def _success_response():
     return response
 
 
-# Catch-all APIFailure messages as the SDK formats them (socketdev/core/api.py); only the
-# embedded original_status_code distinguishes a transient 503/504/408 from e.g. a 400.
+# Catch-all APIFailure as the SDK raises it for statuses without a dedicated class
+# (socketdev/core/api.py); the recorded status_code drives is_transient_error().
 def _catch_all_failure(status_code: int) -> APIFailure:
     return APIFailure(
         f"Bad Request: HTTP original_status_code:{status_code}\n"
         f"Path: https://api.socket.dev/v0/orgs/org/full-scans\n\n"
-        f"Headers:\ncf-ray: abc123"
+        f"Headers:\ncf-ray: abc123",
+        status_code=status_code,
     )
 
 
@@ -121,11 +122,14 @@ def test_upload_raises_after_exhausting_attempts(
     )
 
 
-def test_upload_retries_on_catch_all_503(core_with_mock_sdk, tmp_path, no_sleep):
+@pytest.mark.parametrize("status_code", [408, 503, 504])
+def test_upload_retries_on_catch_all_transient_statuses(
+    core_with_mock_sdk, tmp_path, no_sleep, status_code
+):
     manifest = tmp_path / "package.json"
     manifest.write_text("{}")
     core_with_mock_sdk.sdk.fullscans.post.side_effect = [
-        _catch_all_failure(503),
+        _catch_all_failure(status_code),
         _success_response(),
     ]
 
@@ -164,13 +168,17 @@ def test_upload_does_not_retry_on_400(core_with_mock_sdk, tmp_path, no_sleep):
     no_sleep.assert_not_called()
 
 
-@pytest.mark.parametrize("error_class", [APIAccessDenied, APIResourceNotFound])
+@pytest.mark.parametrize(
+    "error_class,status_code", [(APIAccessDenied, 401), (APIResourceNotFound, 404)]
+)
 def test_upload_does_not_retry_on_dedicated_4xx_classes(
-    core_with_mock_sdk, tmp_path, no_sleep, error_class
+    core_with_mock_sdk, tmp_path, no_sleep, error_class, status_code
 ):
     manifest = tmp_path / "package.json"
     manifest.write_text("{}")
-    core_with_mock_sdk.sdk.fullscans.post.side_effect = error_class()
+    core_with_mock_sdk.sdk.fullscans.post.side_effect = error_class(
+        status_code=status_code
+    )
 
     with pytest.raises(error_class):
         core_with_mock_sdk.create_full_scan([str(manifest)], MagicMock())
@@ -241,25 +249,37 @@ def test_temp_br_file_cleaned_after_exhausted_retries(
     assert not compressed.exists()
 
 
-def test_transient_classifier():
-    assert _is_transient_full_scan_upload_error(APIBadGateway())
-    assert _is_transient_full_scan_upload_error(APIConnectionError())
-    assert _is_transient_full_scan_upload_error(APITimeout())
-    assert _is_transient_full_scan_upload_error(_catch_all_failure(408))
-    assert _is_transient_full_scan_upload_error(_catch_all_failure(503))
-    assert _is_transient_full_scan_upload_error(_catch_all_failure(504))
+class _StubFailure(APIFailure):
+    """An APIFailure whose transience is fixed, regardless of class or status code."""
 
-    assert not _is_transient_full_scan_upload_error(_catch_all_failure(400))
-    assert not _is_transient_full_scan_upload_error(_catch_all_failure(500))
-    assert not _is_transient_full_scan_upload_error(
-        APIFailure()
-    )  # wrapped unexpected error
-    assert not _is_transient_full_scan_upload_error(APIAccessDenied("denied"))
-    assert not _is_transient_full_scan_upload_error(APIResourceNotFound())
-    # Subclasses never match the catch-all branch, even with a retryable-looking message.
-    assert not _is_transient_full_scan_upload_error(
-        APIAccessDenied("original_status_code:503")
-    )
-    assert not _is_transient_full_scan_upload_error(
-        ValueError("original_status_code:503")
-    )
+    def __init__(self, transient: bool):
+        super().__init__("stub failure")
+        self._transient = transient
+
+    def is_transient_error(self) -> bool:
+        return self._transient
+
+
+@pytest.mark.parametrize("transient,expected_calls", [(True, 2), (False, 1)])
+def test_retry_decision_delegates_to_sdk_classification(
+    core_with_mock_sdk, tmp_path, no_sleep, transient, expected_calls
+):
+    # The CLI encodes no knowledge of the SDK's exception hierarchy or status codes:
+    # the retry decision is exactly APIFailure.is_transient_error(). (The transient /
+    # non-transient truth table itself is tested in the SDK, next to the code that
+    # raises the exceptions.)
+    manifest = tmp_path / "package.json"
+    manifest.write_text("{}")
+    core_with_mock_sdk.sdk.fullscans.post.side_effect = [
+        _StubFailure(transient),
+        _success_response(),
+    ]
+
+    if transient:
+        full_scan = core_with_mock_sdk.create_full_scan([str(manifest)], MagicMock())
+        assert full_scan.id == "scan-1"
+    else:
+        with pytest.raises(_StubFailure):
+            core_with_mock_sdk.create_full_scan([str(manifest)], MagicMock())
+
+    assert core_with_mock_sdk.sdk.fullscans.post.call_count == expected_calls

--- a/tests/unit/test_full_scan_retry.py
+++ b/tests/unit/test_full_scan_retry.py
@@ -1,0 +1,265 @@
+"""Tests for the full-scan upload retry on transient gateway/connection failures.
+
+A `POST /orgs/<org>/full-scans` upload can fail transiently (an HTTP 502/503/504/408, a
+dropped or reset connection, or a timeout) without the server having created the scan.
+`Core.create_full_scan` retries those transient failures; these tests cover the retry
+classification, the loop bounds, and that the temporary brotli-compressed facts files
+survive until every attempt has finished.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from socketdev.exceptions import (
+    APIAccessDenied,
+    APIBadGateway,
+    APIConnectionError,
+    APIFailure,
+    APIResourceNotFound,
+    APITimeout,
+)
+from socketdev.fullscans import FullScanMetadata
+
+from socketsecurity.core import (
+    FULL_SCAN_UPLOAD_MAX_ATTEMPTS,
+    SOCKET_FACTS_BROTLI_FILENAME,
+    SOCKET_FACTS_FILENAME,
+    Core,
+    _is_transient_full_scan_upload_error,
+)
+
+
+def _success_response():
+    metadata = FullScanMetadata(
+        id="scan-1",
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+        organization_id="org-1",
+        repository_id="repo-1",
+        branch="main",
+        html_report_url="https://socket.dev/report",
+    )
+    response = MagicMock()
+    response.success = True
+    response.data = metadata
+    return response
+
+
+# Catch-all APIFailure messages as the SDK formats them (socketdev/core/api.py); only the
+# embedded original_status_code distinguishes a transient 503/504/408 from e.g. a 400.
+def _catch_all_failure(status_code: int) -> APIFailure:
+    return APIFailure(
+        f"Bad Request: HTTP original_status_code:{status_code}\n"
+        f"Path: https://api.socket.dev/v0/orgs/org/full-scans\n\n"
+        f"Headers:\ncf-ray: abc123"
+    )
+
+
+@pytest.fixture
+def core_with_mock_sdk():
+    # Build a Core without running org setup; we only exercise create_full_scan.
+    core = Core.__new__(Core)
+    core.sdk = MagicMock()
+    core.cli_config = None  # skip the tier1 finalize branch
+    return core
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(mocker):
+    return mocker.patch("socketsecurity.core.time.sleep")
+
+
+def test_upload_succeeds_first_try(core_with_mock_sdk, tmp_path, no_sleep):
+    manifest = tmp_path / "package.json"
+    manifest.write_text("{}")
+    core_with_mock_sdk.sdk.fullscans.post.return_value = _success_response()
+
+    full_scan = core_with_mock_sdk.create_full_scan([str(manifest)], MagicMock())
+
+    assert full_scan.id == "scan-1"
+    assert core_with_mock_sdk.sdk.fullscans.post.call_count == 1
+    no_sleep.assert_not_called()
+
+
+def test_upload_retries_on_502_then_succeeds(
+    core_with_mock_sdk, tmp_path, no_sleep, caplog
+):
+    manifest = tmp_path / "package.json"
+    manifest.write_text("{}")
+    core_with_mock_sdk.sdk.fullscans.post.side_effect = [
+        APIBadGateway(),
+        APIBadGateway(),
+        _success_response(),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="socketdev"):
+        full_scan = core_with_mock_sdk.create_full_scan([str(manifest)], MagicMock())
+
+    assert full_scan.id == "scan-1"
+    assert core_with_mock_sdk.sdk.fullscans.post.call_count == 3
+    assert no_sleep.call_count == 2  # waits before attempts 2 and 3
+    retry_warnings = [r for r in caplog.records if "retrying in" in r.message]
+    assert len(retry_warnings) == 2
+    assert "APIBadGateway" in retry_warnings[0].message
+    assert f"(attempt 2/{FULL_SCAN_UPLOAD_MAX_ATTEMPTS})" in retry_warnings[0].message
+
+
+def test_upload_raises_after_exhausting_attempts(
+    core_with_mock_sdk, tmp_path, no_sleep
+):
+    manifest = tmp_path / "package.json"
+    manifest.write_text("{}")
+    core_with_mock_sdk.sdk.fullscans.post.side_effect = APIBadGateway()
+
+    with pytest.raises(APIBadGateway):
+        core_with_mock_sdk.create_full_scan([str(manifest)], MagicMock())
+
+    assert (
+        core_with_mock_sdk.sdk.fullscans.post.call_count
+        == FULL_SCAN_UPLOAD_MAX_ATTEMPTS
+    )
+
+
+def test_upload_retries_on_catch_all_503(core_with_mock_sdk, tmp_path, no_sleep):
+    manifest = tmp_path / "package.json"
+    manifest.write_text("{}")
+    core_with_mock_sdk.sdk.fullscans.post.side_effect = [
+        _catch_all_failure(503),
+        _success_response(),
+    ]
+
+    full_scan = core_with_mock_sdk.create_full_scan([str(manifest)], MagicMock())
+
+    assert full_scan.id == "scan-1"
+    assert core_with_mock_sdk.sdk.fullscans.post.call_count == 2
+
+
+@pytest.mark.parametrize("error_class", [APIConnectionError, APITimeout])
+def test_upload_retries_on_connection_level_errors(
+    core_with_mock_sdk, tmp_path, no_sleep, error_class
+):
+    manifest = tmp_path / "package.json"
+    manifest.write_text("{}")
+    core_with_mock_sdk.sdk.fullscans.post.side_effect = [
+        error_class(),
+        _success_response(),
+    ]
+
+    full_scan = core_with_mock_sdk.create_full_scan([str(manifest)], MagicMock())
+
+    assert full_scan.id == "scan-1"
+    assert core_with_mock_sdk.sdk.fullscans.post.call_count == 2
+
+
+def test_upload_does_not_retry_on_400(core_with_mock_sdk, tmp_path, no_sleep):
+    manifest = tmp_path / "package.json"
+    manifest.write_text("{}")
+    core_with_mock_sdk.sdk.fullscans.post.side_effect = _catch_all_failure(400)
+
+    with pytest.raises(APIFailure):
+        core_with_mock_sdk.create_full_scan([str(manifest)], MagicMock())
+
+    assert core_with_mock_sdk.sdk.fullscans.post.call_count == 1
+    no_sleep.assert_not_called()
+
+
+@pytest.mark.parametrize("error_class", [APIAccessDenied, APIResourceNotFound])
+def test_upload_does_not_retry_on_dedicated_4xx_classes(
+    core_with_mock_sdk, tmp_path, no_sleep, error_class
+):
+    manifest = tmp_path / "package.json"
+    manifest.write_text("{}")
+    core_with_mock_sdk.sdk.fullscans.post.side_effect = error_class()
+
+    with pytest.raises(error_class):
+        core_with_mock_sdk.create_full_scan([str(manifest)], MagicMock())
+
+    assert core_with_mock_sdk.sdk.fullscans.post.call_count == 1
+    no_sleep.assert_not_called()
+
+
+def test_upload_does_not_retry_on_error_payload(core_with_mock_sdk, tmp_path, no_sleep):
+    # A response that came back but reports failure (res.success False) is not transient.
+    manifest = tmp_path / "package.json"
+    manifest.write_text("{}")
+    failed = MagicMock()
+    failed.success = False
+    failed.message = "tarball too large"
+    failed.status = 200
+    core_with_mock_sdk.sdk.fullscans.post.return_value = failed
+
+    with pytest.raises(Exception, match="tarball too large"):
+        core_with_mock_sdk.create_full_scan([str(manifest)], MagicMock())
+
+    assert core_with_mock_sdk.sdk.fullscans.post.call_count == 1
+    no_sleep.assert_not_called()
+
+
+def test_temp_br_file_survives_retries_and_is_cleaned_after(
+    core_with_mock_sdk, tmp_path, no_sleep
+):
+    # The brotli-compressed facts sibling must stay on disk across every retry attempt
+    # (the SDK re-reads it per call) and only be deleted once all attempts finished.
+    facts = tmp_path / SOCKET_FACTS_FILENAME
+    facts.write_text('{"components": []}')
+    compressed = tmp_path / SOCKET_FACTS_BROTLI_FILENAME
+    br_present_per_attempt = []
+
+    def post_side_effect(upload_files, *args, **kwargs):
+        br_present_per_attempt.append(compressed.is_file())
+        assert str(compressed) in upload_files
+        if len(br_present_per_attempt) < 3:
+            raise APIBadGateway()
+        return _success_response()
+
+    core_with_mock_sdk.sdk.fullscans.post.side_effect = post_side_effect
+
+    full_scan = core_with_mock_sdk.create_full_scan([str(facts)], MagicMock())
+
+    assert full_scan.id == "scan-1"
+    assert br_present_per_attempt == [True, True, True]
+    assert not compressed.exists()  # cleaned up after the attempts finished
+    assert facts.is_file()  # the original facts file is never touched
+
+
+def test_temp_br_file_cleaned_after_exhausted_retries(
+    core_with_mock_sdk, tmp_path, no_sleep
+):
+    facts = tmp_path / SOCKET_FACTS_FILENAME
+    facts.write_text('{"components": []}')
+    compressed = tmp_path / SOCKET_FACTS_BROTLI_FILENAME
+    core_with_mock_sdk.sdk.fullscans.post.side_effect = APIBadGateway()
+
+    with pytest.raises(APIBadGateway):
+        core_with_mock_sdk.create_full_scan([str(facts)], MagicMock())
+
+    assert (
+        core_with_mock_sdk.sdk.fullscans.post.call_count
+        == FULL_SCAN_UPLOAD_MAX_ATTEMPTS
+    )
+    assert not compressed.exists()
+
+
+def test_transient_classifier():
+    assert _is_transient_full_scan_upload_error(APIBadGateway())
+    assert _is_transient_full_scan_upload_error(APIConnectionError())
+    assert _is_transient_full_scan_upload_error(APITimeout())
+    assert _is_transient_full_scan_upload_error(_catch_all_failure(408))
+    assert _is_transient_full_scan_upload_error(_catch_all_failure(503))
+    assert _is_transient_full_scan_upload_error(_catch_all_failure(504))
+
+    assert not _is_transient_full_scan_upload_error(_catch_all_failure(400))
+    assert not _is_transient_full_scan_upload_error(_catch_all_failure(500))
+    assert not _is_transient_full_scan_upload_error(
+        APIFailure()
+    )  # wrapped unexpected error
+    assert not _is_transient_full_scan_upload_error(APIAccessDenied("denied"))
+    assert not _is_transient_full_scan_upload_error(APIResourceNotFound())
+    # Subclasses never match the catch-all branch, even with a retryable-looking message.
+    assert not _is_transient_full_scan_upload_error(
+        APIAccessDenied("original_status_code:503")
+    )
+    assert not _is_transient_full_scan_upload_error(
+        ValueError("original_status_code:503")
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1283,7 +1283,7 @@ wheels = [
 
 [[package]]
 name = "socketsecurity"
-version = "2.4.7"
+version = "2.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "brotli", marker = "platform_python_implementation == 'CPython'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1270,15 +1270,15 @@ wheels = [
 
 [[package]]
 name = "socketdev"
-version = "3.2.1"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/65/07df2bf6e490c56544fb06e4cfde059b2572fdd5b02ff352c766b1d5f7ce/socketdev-3.2.1.tar.gz", hash = "sha256:7db910a98628473e8ec06822deb01b6bd465b385e9e8ea405f2b7526e8258074", size = 179279, upload-time = "2026-06-03T18:08:19.806Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/30/16155f7f27d18274f364b3bd3506ee45d17f53fc8938aaea9a618054449b/socketdev-3.3.0.tar.gz", hash = "sha256:3d60bd4ac3201e9d581b1fe02bf2e6aef1b90c13ae75d15a8664aa9ef966734e", size = 181519, upload-time = "2026-06-10T11:41:17.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/01/fff70923755b3a187ca971189fb078a2aaedcad42d682abfdd06f3445def/socketdev-3.2.1-py3-none-any.whl", hash = "sha256:6dc762d78baea8011dc22f2afe49c84c926e640a6879bd7b58c3abdd4e29e8bb", size = 67266, upload-time = "2026-06-03T18:08:18.029Z" },
+    { url = "https://files.pythonhosted.org/packages/33/dd/25622e033182e8c744d2420bb4f056206edc096a1e5ce8e4af4b0a0c0791/socketdev-3.3.0-py3-none-any.whl", hash = "sha256:513c045ce42bdd6cc2bb66a527f5863e0c399e56dbdcb1832cd5d94a5fb1a5e4", size = 67956, upload-time = "2026-06-10T11:41:16.534Z" },
 ]
 
 [[package]]
@@ -1340,7 +1340,7 @@ requires-dist = [
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
-    { name = "socketdev", specifier = ">=3.2.1,<4.0.0" },
+    { name = "socketdev", specifier = ">=3.3.0,<4.0.0" },
     { name = "twine", marker = "extra == 'dev'" },
     { name = "uv", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]


### PR DESCRIPTION
## Problem

The full-scan upload (`POST /v0/orgs/<org>/full-scans`) makes exactly one attempt. When it fails, the entire run dies — for `--reach` runs that means a completed multi-hour tier-1 reachability analysis produces no scan and no report.

Uploads can fail transiently at the gateway/connection level — an HTTP 502/503/504/408, a dropped or reset connection, or a client-side timeout — without the server having created the scan. A retried upload almost always succeeds.

## Change

`Core.create_full_scan` now retries the `fullscans.post` call:

- **Up to 3 total attempts**, waiting ~10s before attempt 2 and ~30s before attempt 3 (plus up to 2s jitter so CI fleets don't retry in lock-step), with a `log.warning` before each retry.
- **Retries transient failures only**, as classified by the SDK: requires `socketdev>=3.3.0` (SocketDev/socket-sdk-python#93), where `do_request` records the HTTP status code on every exception it raises and `APIFailure.is_transient_error()` owns the classification — true for HTTP 408/502/503/504, dropped/reset connections, and client-side timeouts. The CLI encodes no knowledge of the SDK exception hierarchy and parses no message text, so SDK restructuring can't silently break the classification.
- **Never retried**: deterministic errors (400/401/403/404/429), responses that came back with an error payload, and unexpected errors wrapped in a bare `APIFailure`.

> **Note**: `uv.lock` is regenerated once `socketdev 3.3.0` is released to PyPI (blocked on SocketDev/socket-sdk-python#93); CI is expected to fail on dependency resolution until then.

### Safety

- **No duplicate scans**: in these failure modes the server never finished reading the request body, so no scan was created — a retry cannot duplicate one. In the rare case where a gateway timeout races a request the server later completes, the extra scan is benign and superseded by the retry (as if the CLI had run twice).
- **Files are rebuilt per attempt**: `fullscans.post(use_lazy_loading=True)` rebuilds its `LazyFileLoader`s from the plain paths on every call, so re-invoking it is safe (the loaders from a failed attempt are exhausted/closed and must not be reused).
- **Temp `.br` facts files survive retries**: the retry loop lives inside the existing `try`/`finally`, so the brotli-compressed `.socket.facts.json.br` siblings are only cleaned up after the last attempt.

## Testing

New `tests/unit/test_full_scan_retry.py` (16 tests): retry on 502 then success, exhausting attempts re-raises, retry on catch-all 408/503/504, retry on connection-level errors, no retry on 400 / dedicated 4xx classes / error payloads, `.br` temp-file lifecycle across retries (success and exhaustion), and that the retry decision delegates to `APIFailure.is_transient_error()` (the classification truth table itself is tested in the SDK, next to the code that raises). Full suite against socketdev 3.3.0: **364 passed, 2 pre-existing skips**.

