### PR TITLE
Fix intermittent connection resets on scan comparison by polling the diff-scans endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.5.0
+
+### Changed: scan comparison now polls the diff-scans endpoints
+
+- Diff mode no longer holds a single idle HTTP connection open while the API
+  computes the scan comparison. The CLI now creates a diff-scan resource
+  (`POST /orgs/{org}/diff-scans/from-ids`) and polls
+  `GET /orgs/{org}/diff-scans/{id}?cached=true` with short, bounded requests
+  until the comparison is ready (HTTP 200 instead of 202). This fixes
+  intermittent `Connection reset by peer` failures on the final comparison
+  step when scans take several minutes to compare and network middleboxes
+  (e.g. Azure NAT gateways, which default to a 4-minute TCP idle timeout)
+  reap the idle connection (CE-354).
+- The change is transparent: no flags or workflow changes are needed. If the
+  org API token is missing the `diff-scans:create`, `diff-scans:list` or
+  `full-scans:list` scopes — or the new flow fails for any other reason — the
+  CLI logs a warning and falls back to the legacy streaming comparison.
+- Requires `socketdev>=3.4.0`.
+
 ## 2.4.20
 
 ### Changed: bump pinned @coana-tech/cli to 15.8.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.4.20"
+version = "2.5.0"
 requires-python = ">= 3.11"
 license = {"file" = "LICENSE"}
 dependencies = [
@@ -16,7 +16,7 @@ dependencies = [
     'GitPython',
     'packaging',
     'python-dotenv',
-    "socketdev>=3.3.0,<4.0.0",
+    "socketdev>=3.4.0,<4.0.0",
     "bs4>=0.0.2",
     "markdown>=3.10",
     "brotli>=1.0.9; platform_python_implementation == 'CPython'",

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.4.20'
+__version__ = '2.5.0'
 USER_AGENT = f'SocketPythonCLI/{__version__}'

--- a/socketsecurity/core/__init__.py
+++ b/socketsecurity/core/__init__.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from socketsecurity.config import CliConfig
 from socketdev import socketdev
 from socketdev.exceptions import APIFailure
-from socketdev.fullscans import FullScanParams, SocketArtifact
+from socketdev.fullscans import DiffArtifacts, FullScanParams, SocketArtifact
 from socketdev.org import Organization
 from socketdev.repos import RepositoryInfo
 import copy
@@ -91,6 +91,25 @@ TIER1_FINALIZE_BACKOFF_SECONDS = 1.0
 FULL_SCAN_UPLOAD_BACKOFF_SCHEDULE_SECONDS = (10.0, 30.0, None)
 FULL_SCAN_UPLOAD_MAX_ATTEMPTS = len(FULL_SCAN_UPLOAD_BACKOFF_SCHEDULE_SECONDS)
 FULL_SCAN_UPLOAD_BACKOFF_JITTER_SECONDS = 2.0
+
+# Diff-scan polling policy. The legacy scan comparison (fullscans.stream_diff) holds a
+# single HTTP connection open, fully idle, while the backend computes the diff; network
+# middleboxes with TCP idle timeouts (notably Azure NAT gateways, which default to
+# 4 minutes) kill that connection with a RST, surfacing as an intermittent
+# ConnectionResetError on large scans (CE-354). The diff-scans flow instead creates a
+# diff-scan resource and polls its cached endpoint with short bounded requests: the API
+# answers 202 while the comparison is still computing and 200 with the result once it is
+# ready, so no connection is ever idle long enough to be reaped.
+#
+# Each poll consumes 1 unit of API quota, so the interval backs off toward
+# DIFF_SCAN_POLL_MAX_INTERVAL_SECONDS to stay quota-friendly on comparisons that take
+# minutes to compute. The timeout is a backstop against a diff scan that never
+# completes; on expiry (or any other failure of this flow) the caller falls back to the
+# legacy streaming comparison rather than failing the scan outright.
+DIFF_SCAN_POLL_INITIAL_INTERVAL_SECONDS = 5.0
+DIFF_SCAN_POLL_MAX_INTERVAL_SECONDS = 30.0
+DIFF_SCAN_POLL_BACKOFF_MULTIPLIER = 1.5
+DIFF_SCAN_POLL_TIMEOUT_SECONDS = 30 * 60.0
 
 
 def _humanize_alert_type(alert_type: str) -> str:
@@ -1215,6 +1234,93 @@ class Core:
         
         return packages
 
+    def get_diff_scan_artifacts(
+            self,
+            head_full_scan_id: str,
+            new_full_scan_id: str,
+            include_license_details: bool = False
+    ) -> DiffArtifacts:
+        """Compare two full scans via the diff-scans endpoints, polling for the result.
+
+        Creates a diff-scan resource from the two full scan IDs, then polls
+        ``GET /orgs/{org}/diff-scans/{id}?cached=true`` until the API returns the
+        computed comparison (200) instead of a processing status (202). Unlike the
+        legacy ``fullscans.stream_diff`` call, no request is ever left idle while
+        the backend computes, so the comparison survives network idle timeouts
+        (CE-354). See the DIFF_SCAN_POLL_* constants for the polling policy.
+
+        Requires an org token with the ``diff-scans:create``, ``diff-scans:list``
+        and ``full-scans:list`` scopes; callers are expected to catch failures and
+        fall back to the legacy streaming comparison.
+
+        Args:
+            head_full_scan_id: The before/base full scan ID
+            new_full_scan_id: The after/head full scan ID
+            include_license_details: Whether to keep embedded per-package license
+                details in the response (see get_added_and_removed_packages for
+                why this defaults to False)
+
+        Returns:
+            DiffArtifacts with the added/removed/unchanged/replaced/updated lists
+        """
+        create_params = {
+            "before": head_full_scan_id,
+            "after": new_full_scan_id,
+            "description": f"Socket Security CLI v{__version__} scan comparison",
+            # A rerun against the same pair of scans returns the existing diff
+            # scan instead of failing with a 409.
+            "on_duplicate": "redirect",
+        }
+        result = self.sdk.diffscans.create_from_ids(self.config.org_slug, create_params)
+        diff_scan = result.get("diff_scan") or {}
+        diff_scan_id = diff_scan.get("id")
+        if not diff_scan_id:
+            raise Exception(f"Error creating diff scan: unexpected response: {str(result)[:500]}")
+        # An on_duplicate redirect can land on an already-computed diff scan, in
+        # which case the create response already carries the artifacts.
+        artifacts_dict = diff_scan.get("artifacts")
+
+        poll_params = {
+            "cached": "true",
+            "omit_license_details": "false" if include_license_details else "true",
+        }
+        deadline = time.monotonic() + DIFF_SCAN_POLL_TIMEOUT_SECONDS
+        interval = DIFF_SCAN_POLL_INITIAL_INTERVAL_SECONDS
+        while artifacts_dict is None:
+            try:
+                response = self.sdk.diffscans.get(self.config.org_slug, diff_scan_id, params=poll_params)
+            except APIFailure as error:
+                if not error.is_transient_error():
+                    raise
+                # A dropped/timed-out poll is retryable: the diff scan keeps
+                # computing server-side regardless of what happens to any one poll.
+                log.warning(
+                    f"Transient error polling diff scan {diff_scan_id} "
+                    f"({type(error).__name__}), retrying in {interval:.0f}s"
+                )
+                response = {"status": "processing"}
+            if response.get("status") != "processing":
+                scan = response.get("diff_scan") or {}
+                if scan.get("artifacts") is None:
+                    raise Exception(
+                        f"Error fetching diff scan {diff_scan_id}: unexpected response: {str(response)[:500]}"
+                    )
+                artifacts_dict = scan["artifacts"]
+                break
+            if time.monotonic() >= deadline:
+                raise Exception(
+                    f"Timed out waiting for diff scan {diff_scan_id} after "
+                    f"{DIFF_SCAN_POLL_TIMEOUT_SECONDS:.0f} seconds"
+                )
+            log.debug(f"Diff scan {diff_scan_id} still processing, polling again in {interval:.0f}s")
+            time.sleep(interval)
+            interval = min(interval * DIFF_SCAN_POLL_BACKOFF_MULTIPLIER, DIFF_SCAN_POLL_MAX_INTERVAL_SECONDS)
+
+        return DiffArtifacts.from_dict({
+            key: artifacts_dict.get(key) or []
+            for key in ("added", "removed", "unchanged", "replaced", "updated")
+        })
+
     def get_added_and_removed_packages(
             self,
             head_full_scan_id: str,
@@ -1255,39 +1361,56 @@ class Core:
 
         log.info(f"Comparing scans - Head scan ID: {head_full_scan_id}, New scan ID: {new_full_scan_id}")
         diff_start = time.time()
+        diff_artifacts = None
         try:
-            diff_report = (
-                self.sdk.fullscans.stream_diff(
-                    self.config.org_slug,
-                    head_full_scan_id,
-                    new_full_scan_id,
-                    use_types=True,
-                    include_license_details=str(include_license_details).lower()
-                ).data
+            diff_artifacts = self.get_diff_scan_artifacts(
+                head_full_scan_id,
+                new_full_scan_id,
+                include_license_details=include_license_details
             )
-        except APIFailure as e:
-            log.error(f"API Error: {e}")
-            if self.cli_config and self.cli_config.disable_blocking:
-                sys.exit(0)
-            sys.exit(1)
-        except Exception as e:
-            import traceback
-            log.error(f"Error getting diff report: {str(e)}")
-            log.error(f"Stack trace:\n{traceback.format_exc()}")
-            raise
+        except Exception as error:
+            # SDK error messages can span many lines (path + response headers); the
+            # first line carries the status, which is all the warning needs.
+            error_summary = str(error).strip().splitlines()[0] if str(error).strip() else ""
+            log.warning(
+                f"Diff scan comparison failed with {type(error).__name__}({error_summary}), "
+                "falling back to the streaming scan comparison"
+            )
+
+        if diff_artifacts is None:
+            try:
+                diff_artifacts = (
+                    self.sdk.fullscans.stream_diff(
+                        self.config.org_slug,
+                        head_full_scan_id,
+                        new_full_scan_id,
+                        use_types=True,
+                        include_license_details=str(include_license_details).lower()
+                    ).data.artifacts
+                )
+            except APIFailure as e:
+                log.error(f"API Error: {e}")
+                if self.cli_config and self.cli_config.disable_blocking:
+                    sys.exit(0)
+                sys.exit(1)
+            except Exception as e:
+                import traceback
+                log.error(f"Error getting diff report: {str(e)}")
+                log.error(f"Stack trace:\n{traceback.format_exc()}")
+                raise
 
         diff_end = time.time()
         log.info(f"Diff Report Gathered in {diff_end - diff_start:.2f} seconds")
         log.info("Diff report artifact counts:")
-        log.info(f"Added: {len(diff_report.artifacts.added)}")
-        log.info(f"Removed: {len(diff_report.artifacts.removed)}")
-        log.info(f"Unchanged: {len(diff_report.artifacts.unchanged)}")
-        log.info(f"Replaced: {len(diff_report.artifacts.replaced)}")
-        log.info(f"Updated: {len(diff_report.artifacts.updated)}")
+        log.info(f"Added: {len(diff_artifacts.added)}")
+        log.info(f"Removed: {len(diff_artifacts.removed)}")
+        log.info(f"Unchanged: {len(diff_artifacts.unchanged)}")
+        log.info(f"Replaced: {len(diff_artifacts.replaced)}")
+        log.info(f"Updated: {len(diff_artifacts.updated)}")
 
-        added_artifacts = diff_report.artifacts.added + diff_report.artifacts.updated
-        removed_artifacts = diff_report.artifacts.removed + diff_report.artifacts.replaced
-        unchanged_artifacts = diff_report.artifacts.unchanged
+        added_artifacts = diff_artifacts.added + diff_artifacts.updated
+        removed_artifacts = diff_artifacts.removed + diff_artifacts.replaced
+        unchanged_artifacts = diff_artifacts.unchanged
 
         added_packages: Dict[str, Package] = {}
         removed_packages: Dict[str, Package] = {}

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -87,6 +87,22 @@ def stream_diff_response(data_dir, load_json):
     })
 
 
+@pytest.fixture
+def diff_scan_get_response(data_dir, load_json):
+    """GET /orgs/{org}/diff-scans/{id} response built from the stream_diff fixture.
+
+    The diff-scans endpoint returns the same artifact shape as the legacy
+    streaming diff, wrapped in a diff_scan object.
+    """
+    json_data = load_json(data_dir / "fullscans" / "diff" / "stream_diff.json")
+    return {
+        "diff_scan": {
+            "id": "diff-scan-123",
+            "artifacts": json_data["data"]["artifacts"],
+        }
+    }
+
+
 
 
 
@@ -138,6 +154,7 @@ def mock_sdk_with_responses(
     new_scan_metadata,
     new_scan_stream,
     stream_diff_response,
+    diff_scan_get_response,
     create_full_scan_response,
 ):
     sdk = mock_socket_sdk.return_value
@@ -172,5 +189,9 @@ def mock_sdk_with_responses(
     sdk.fullscans.stream_diff.side_effect = (
         lambda org_slug, head_id, new_id, **kwargs: stream_diff_response
     )
+
+    # Diff-scans endpoints (primary scan-comparison path)
+    sdk.diffscans.create_from_ids.return_value = {"diff_scan": {"id": "diff-scan-123"}}
+    sdk.diffscans.get.return_value = diff_scan_get_response
 
     return sdk

--- a/tests/core/test_diff_scan_polling.py
+++ b/tests/core/test_diff_scan_polling.py
@@ -1,0 +1,103 @@
+"""Tests for the diff-scans polling scan comparison (CE-354).
+
+The comparison must never hold an idle connection open: it creates a diff-scan
+resource and polls the cached endpoint (202 while processing, 200 when ready),
+falling back to the legacy streaming diff if the new flow is unavailable.
+"""
+import pytest
+from socketdev.exceptions import APIConnectionError, APIFailure
+
+import socketsecurity.core as core_module
+from socketsecurity.core import Core
+from socketsecurity.core.socket_config import SocketConfig
+
+
+@pytest.fixture
+def core(mock_sdk_with_responses):
+    config = SocketConfig(api_key="test_key")
+    return Core(config=config, sdk=mock_sdk_with_responses)
+
+
+@pytest.fixture
+def no_sleep(mocker):
+    return mocker.patch("socketsecurity.core.time.sleep")
+
+
+def test_polls_until_diff_scan_ready(core, diff_scan_get_response, no_sleep):
+    """202 processing responses are polled through until the 200 result arrives."""
+    processing = {"status": "processing", "id": "diff-scan-123"}
+    core.sdk.diffscans.get.side_effect = [processing, processing, diff_scan_get_response]
+
+    artifacts = core.get_diff_scan_artifacts("head", "new")
+
+    assert core.sdk.diffscans.get.call_count == 3
+    assert no_sleep.call_count == 2  # slept between polls, never during them
+    assert len(artifacts.added) > 0
+
+
+def test_poll_interval_backs_off(core, diff_scan_get_response, no_sleep, monkeypatch):
+    """The poll interval grows toward the max so long comparisons stay quota-friendly."""
+    monkeypatch.setattr(core_module, "DIFF_SCAN_POLL_INITIAL_INTERVAL_SECONDS", 4.0)
+    monkeypatch.setattr(core_module, "DIFF_SCAN_POLL_MAX_INTERVAL_SECONDS", 10.0)
+    processing = {"status": "processing", "id": "diff-scan-123"}
+    core.sdk.diffscans.get.side_effect = [processing] * 4 + [diff_scan_get_response]
+
+    core.get_diff_scan_artifacts("head", "new")
+
+    waits = [call.args[0] for call in no_sleep.call_args_list]
+    assert waits == [4.0, 6.0, 9.0, 10.0]  # 1.5x backoff, capped at the max
+
+
+def test_transient_poll_error_is_retried(core, diff_scan_get_response, no_sleep):
+    """A dropped poll doesn't abandon the flow - the diff keeps computing server-side."""
+    core.sdk.diffscans.get.side_effect = [APIConnectionError("reset"), diff_scan_get_response]
+
+    artifacts = core.get_diff_scan_artifacts("head", "new")
+
+    assert core.sdk.diffscans.get.call_count == 2
+    assert len(artifacts.added) > 0
+
+
+def test_non_transient_poll_error_raises(core, no_sleep):
+    """Deterministic API errors (e.g. 403 missing scopes) propagate to the caller."""
+    core.sdk.diffscans.get.side_effect = APIFailure("forbidden", status_code=403)
+
+    with pytest.raises(APIFailure):
+        core.get_diff_scan_artifacts("head", "new")
+
+
+def test_poll_timeout_raises(core, no_sleep, monkeypatch):
+    """A diff scan that never completes hits the polling backstop."""
+    monkeypatch.setattr(core_module, "DIFF_SCAN_POLL_TIMEOUT_SECONDS", 0.0)
+    core.sdk.diffscans.get.return_value = {"status": "processing", "id": "diff-scan-123"}
+
+    with pytest.raises(Exception, match="Timed out waiting for diff scan"):
+        core.get_diff_scan_artifacts("head", "new")
+
+
+def test_duplicate_redirect_uses_embedded_artifacts(core, diff_scan_get_response):
+    """An on_duplicate redirect can return the computed diff scan straight away."""
+    core.sdk.diffscans.create_from_ids.return_value = diff_scan_get_response
+
+    artifacts = core.get_diff_scan_artifacts("head", "new")
+
+    core.sdk.diffscans.get.assert_not_called()
+    assert len(artifacts.added) > 0
+
+
+def test_fallback_to_streaming_diff_on_failure(core):
+    """If the diff-scans flow fails (e.g. token missing the diff-scans scopes),
+    the comparison falls back to the legacy streaming diff transparently."""
+    core.sdk.diffscans.create_from_ids.side_effect = APIFailure("forbidden", status_code=403)
+
+    added, removed, all_packages = core.get_added_and_removed_packages("head", "new")
+
+    core.sdk.fullscans.stream_diff.assert_called_once_with(
+        core.config.org_slug,
+        "head",
+        "new",
+        use_types=True,
+        include_license_details="false",
+    )
+    assert "dp3" in added
+    assert "dp2" in removed

--- a/tests/core/test_sdk_methods.py
+++ b/tests/core/test_sdk_methods.py
@@ -94,19 +94,27 @@ def test_get_added_and_removed_packages(core):
     """Test getting added and removed packages between two scans"""
     # Get two different scans to compare
     added, removed, all_packages = core.get_added_and_removed_packages("head", "new")
-    
-    # Verify SDK was called correctly.
-    # include_license_details defaults to "false": the diff path never consumes
+
+    # Verify SDK was called correctly: the comparison goes through the diff-scans
+    # endpoints (create + poll) rather than the legacy streaming diff, so no
+    # connection is left idle while the backend computes (CE-354).
+    create_args = core.sdk.diffscans.create_from_ids.call_args
+    assert create_args[0][0] == core.config.org_slug
+    create_params = create_args[0][1]
+    assert create_params["before"] == "head"
+    assert create_params["after"] == "new"
+    assert create_params["on_duplicate"] == "redirect"
+
+    # include_license_details defaults to False: the diff path never consumes
     # embedded license data (license artifacts come from the PURL endpoint), so
     # requesting it only bloats the response and risks the CE-224 truncation
     # crash on large repos.
-    core.sdk.fullscans.stream_diff.assert_called_once_with(
+    core.sdk.diffscans.get.assert_called_once_with(
         core.config.org_slug,
-        "head",
-        "new",
-        use_types=True,
-        include_license_details="false",
+        "diff-scan-123",
+        params={"cached": "true", "omit_license_details": "true"},
     )
+    core.sdk.fullscans.stream_diff.assert_not_called()
     
     # Verify the results
     # Added packages
@@ -124,12 +132,10 @@ def test_get_added_and_removed_packages_license_override(core):
     """The include_license_details override seam still works when explicitly requested."""
     core.get_added_and_removed_packages("head", "new", include_license_details=True)
 
-    core.sdk.fullscans.stream_diff.assert_called_once_with(
+    core.sdk.diffscans.get.assert_called_once_with(
         core.config.org_slug,
-        "head",
-        "new",
-        use_types=True,
-        include_license_details="true",
+        "diff-scan-123",
+        params={"cached": "true", "omit_license_details": "false"},
     )
 
 def test_empty_alerts_preserved(core):


### PR DESCRIPTION
<!--Description: Briefly describe the bug and its impact. If there's a related Linear ticket or Sentry issue, link it here. ⬇️ -->
Diff-mode scans on self-hosted CI runners intermittently fail on the final comparison step with `Connection error after 261.68 seconds: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))` followed by a blank `API Error:`, even though the full scan itself succeeded and the results are on the dashboard.

## Root Cause
The scan comparison used `fullscans.stream_diff`, which sends one request and then holds the connection open — completely idle — while the API computes the diff. When the comparison takes longer than a network middlebox's TCP idle timeout (Azure NAT gateways default to 4 minutes; the reported resets fired at ~262s on runners egressing through Azure), the middlebox reaps the "zombie" connection and sends a RST. Our API logs show `request aborted` (client-side termination) with no response ever written. Intermittency tracks diff computation time: fast diffs finish before the idle timer, slow ones (no baseline / large dependency trees) don't.

## Fix
Per dougbot's suggestion, the comparison now uses the diff-scans endpoints with polling instead of a held-open connection:

1. `POST /orgs/{org}/diff-scans/from-ids` creates a diff-scan resource for the two full scans (returns metadata immediately; `on_duplicate=redirect` makes reruns of the same pair benign).
2. The CLI polls `GET /orgs/{org}/diff-scans/{id}?cached=true` — the API answers **202** while the diff is computing and **200** with the artifacts once ready. Every request is short and bounded, so nothing is ever idle long enough to be reaped.

Details:
- Poll interval backs off 5s → 30s (1.5×), since each poll consumes 1 quota unit; 30-minute backstop timeout.
- Transient poll failures (connection reset/timeout/502-class, via `APIFailure.is_transient_error()`) retry within the loop — the diff keeps computing server-side regardless.
- **Fallback:** any failure of the new flow logs a warning and falls back to the legacy `stream_diff` path, so tokens missing the newly-required scopes (`diff-scans:create`, `diff-scans:list`, `full-scans:list`) keep working exactly as today. No flags, no behavior change otherwise — full-scan creation, head-scan management, and reachability finalize are untouched.
- `omit_license_details` mirrors the existing lean-diff behavior from CE-224.

**Dependencies / rollout:**
- Requires `socketdev>=3.4.0` — companion SDK PR: SocketDev/socket-sdk-python#97 (adds query-param + 202 support to `diffscans.get`). The SDK must be released to PyPI first; `uv.lock` needs regenerating after that (lockfile intentionally not updated here since 3.4.0 isn't published yet).
- Version bumped to 2.5.0.

**Testing:** new `tests/core/test_diff_scan_polling.py` covers poll-until-ready, backoff schedule, transient-error retry, non-transient propagation, timeout backstop, duplicate-redirect shortcut, and the streaming fallback. Full suite: 413 passed, 2 skipped (run against the local SDK build).

## Public Changelog

<!-- changelog ⬇️-->
Diff-mode scan comparison no longer holds an idle HTTP connection open while the API computes the diff. The CLI now polls the diff-scans endpoints with short bounded requests, fixing intermittent "Connection reset by peer" failures on the final comparison step behind network gear with TCP idle timeouts (e.g. Azure NAT gateways). The change is transparent; if the API token lacks the diff-scans scopes the CLI falls back to the previous behavior.
<!-- /changelog ⬆️ -->

<!-- TEMPLATE TYPE DON'T REMOVE: python-cli-template-bug-fix -->