### PR TITLE
chore(deps): bump socketdev floor to >=3.4.0 (CE-360)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     'GitPython',
     'packaging',
     'python-dotenv',
-    "socketdev>=3.3.0,<4.0.0",
+    "socketdev>=3.4.0,<4.0.0",
     "bs4>=0.0.2",
     "markdown>=3.10",
     "brotli>=1.0.9; platform_python_implementation == 'CPython'",


### PR DESCRIPTION
> **Draft — blocked on `socketdev` 3.4.0 reaching PyPI** (SocketDev/socket-sdk-python#98). Opened now as a tracker so the SDK→CLI dependency bump isn't forgotten; do not merge until 3.4.0 publishes, then regenerate `uv.lock`.

## What & why

Bumps the `socketdev` floor `>=3.3.0,<4.0.0` → `>=3.4.0,<4.0.0` to track [socketdev 3.4.0](https://github.com/SocketDev/socket-sdk-python/pull/98) (the fail-open batch-purl fix, **[CE-360](https://linear.app/socketdev/issue/CE-360/purlpost-silently-inherits-the-batch-apis-fail-open-row-omission)**).

**No code change.** The CLI's only `purl.post` call site is `get_license_text_via_purl` (`socketsecurity/core/__init__.py`) — license enrichment, not security scoring. It uses none of the new 3.4.0 params (`poll`/`timeout_sec`/`alerts`/`strict`) and intentionally stays fail-open (skipping license attribution for still-pending packages is acceptable; opting into `alerts=True` would inject synthetic rows that lack `type`/`name`/`version` and break its result loop). So there's nothing to migrate here — this is purely the dependency floor bump.

## Not done here (blocked)

- `uv.lock` **not** regenerated — `uv lock` can't resolve `>=3.4.0` until it's on PyPI. Regenerate once 3.4.0 publishes (Dependabot will also propose it).

## Sequencing

1. Merge + publish socketdev 3.4.0 (socket-sdk-python#98)
2. Un-draft this, `uv lock`, merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
