### PR TITLE
Make package and Docker previews opt-in

### DIFF
--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -5,6 +5,10 @@ description: >-
   preview, and stable workflows.
 
 inputs:
+  enable-qemu:
+    description: "Set up QEMU for multi-platform builds"
+    required: false
+    default: "true"
   dockerhub-username:
     description: "Docker Hub username (pass from secrets)"
     required: true
@@ -16,6 +20,7 @@ runs:
   using: "composite"
   steps:
     - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+      if: inputs.enable-qemu == 'true'
     - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
     - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -571,7 +571,10 @@ jobs:
           persist-credentials: false
 
       - name: Build the Dockerfile (no push)
-        run: docker build --pull -t socket-python-cli:dependabot-smoke .
+        run: >-
+          docker build --pull
+          --build-arg USE_LOCAL_INSTALL=true
+          -t socket-python-cli:dependabot-smoke .
 
   workflow-notice:
     needs: inspect

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -1,0 +1,66 @@
+name: Package Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: package-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  package-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        uses: ./.github/actions/setup-hatch
+
+      - name: Install distribution validator
+        run: python -m pip install "twine>=4.0.0"
+
+      - name: Build distributions
+        run: hatch build
+
+      - name: Validate distributions
+        run: python -m twine check dist/*
+
+      - name: Install and inspect wheel without resolving dependencies
+        run: |
+          python -m venv "$RUNNER_TEMP/package-check"
+          "$RUNNER_TEMP/package-check/bin/pip" install --no-deps dist/*.whl
+          "$RUNNER_TEMP/package-check/bin/python" - <<'PY'
+          import compileall
+          import importlib.metadata
+          import pathlib
+          import sysconfig
+
+          distribution = importlib.metadata.distribution("socketsecurity")
+          entry_points = {entry_point.name for entry_point in distribution.entry_points}
+          assert "socketcli" in entry_points
+          package = pathlib.Path(sysconfig.get_paths()["purelib"]) / "socketsecurity"
+          assert compileall.compile_dir(package, quiet=1)
+          print("wheel metadata and bytecode smoke OK", distribution.version)
+          PY
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: socketsecurity-${{ github.sha }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,169 +1,254 @@
-name: PR Preview
+name: Publish PR Preview
+
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to publish
+        required: true
+        type: string
+      publish_test_pypi:
+        description: Publish the Python package to TestPyPI
+        required: true
+        default: true
+        type: boolean
+      publish_docker:
+        description: Publish socketdev/cli:pr-<number> to Docker Hub
+        required: true
+        default: false
+        type: boolean
+      sdk_preview_version:
+        description: Optional exact TestPyPI socketdev prerelease for the Docker image
+        required: false
+        type: string
 
-# Cancel an in-flight preview when the PR is pushed again -- previews are slow
-# (publish + multi-step Docker build), so superseded runs shouldn't keep going.
 concurrency:
-  group: pr-preview-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: publish-pr-preview-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
 
 jobs:
-  preview:
-    # Skip on:
-    #  - PRs from forks (no access to publish secrets)
-    #  - Dependabot PRs: preview-publishing a dependency bump to Test PyPI /
-    #    Docker Hub is pointless and fails (no version bump, secret access).
+  build:
     if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event_name == 'workflow_dispatch' ||
+      ((github.event.label.name == 'publish-preview' ||
+      github.event.label.name == 'publish-docker-preview') &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
-      id-token: write
       contents: read
-      pull-requests: write
+    outputs:
+      preview_version: ${{ steps.version.outputs.preview_version }}
+      pr_number: ${{ steps.context.outputs.pr_number }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', inputs.pr_number) }}
           fetch-depth: 0
           persist-credentials: false
+
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.13'
+          python-version: "3.12"
 
       - name: Install build tooling
         uses: ./.github/actions/setup-hatch
 
-      - name: Inject full dynamic version
-        run: python .hooks/sync_version.py --dev
+      - name: Install distribution validator
+        run: python -m pip install "twine>=4.0.0"
 
-      - name: Clean previous builds
-        run: rm -rf dist/ build/ *.egg-info
-
-      - name: Get Hatch version
-        id: version
-        run: |
-          VERSION=$(hatch version | cut -d+ -f1)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-      - name: Check if version already exists on Test PyPI
-        id: version_check
+      - name: Record preview context
+        id: context
         env:
-          VERSION: ${{ env.VERSION }}
-        run: |
-          if curl -s -f https://test.pypi.org/pypi/socketsecurity/${VERSION}/json > /dev/null; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        run: echo "pr_number=${EVENT_PR_NUMBER:-$INPUT_PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
-      - name: Build package
-        if: steps.version_check.outputs.exists != 'true'
+      - name: Inject deterministic preview version
+        env:
+          PREVIEW_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          PREVIEW_ID=$((PREVIEW_ID * 100 + RUN_ATTEMPT))
+          python .hooks/sync_version.py --dev --preview-id "$PREVIEW_ID" --skip-lock
+
+      - name: Read preview version
+        id: version
+        run: echo "preview_version=$(hatch version)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and validate distributions
         run: |
           hatch build
+          python -m twine check dist/*
 
-      - name: Publish to Test PyPI
-        if: steps.version_check.outputs.exists != 'true'
+      - name: Install and inspect wheel locally
+        run: |
+          python -m venv "$RUNNER_TEMP/preview-check"
+          "$RUNNER_TEMP/preview-check/bin/pip" install --no-deps dist/*.whl
+          "$RUNNER_TEMP/preview-check/bin/python" - <<'PY'
+          import compileall
+          import importlib.metadata
+          import pathlib
+          import sysconfig
+
+          distribution = importlib.metadata.distribution("socketsecurity")
+          entry_points = {entry_point.name for entry_point in distribution.entry_points}
+          assert "socketcli" in entry_points
+          package = pathlib.Path(sysconfig.get_paths()["purelib"]) / "socketsecurity"
+          assert compileall.compile_dir(package, quiet=1)
+          print("preview wheel smoke OK", distribution.version)
+          PY
+
+      - name: Upload preview distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: socketsecurity-preview-${{ github.run_id }}-${{ github.run_attempt }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 14
+
+  publish-package:
+    needs: build
+    if: >-
+      github.event.label.name == 'publish-preview' ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish_test_pypi)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Download preview distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: socketsecurity-preview-${{ github.run_id }}-${{ github.run_attempt }}
+          path: dist
+
+      - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           repository-url: https://test.pypi.org/legacy/
           verbose: true
 
-      - name: Comment on PR
-        if: steps.version_check.outputs.exists != 'true'
+      - name: Comment on pull request
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          VERSION: ${{ env.VERSION }}
+          PREVIEW_VERSION: ${{ needs.build.outputs.preview_version }}
+          PR_NUMBER: ${{ needs.build.outputs.pr_number }}
         with:
           script: |
-            const version = process.env.VERSION;
-            const prNumber = context.payload.pull_request.number;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            // Find existing bot comments
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
+            const marker = '<!-- socketsecurity-pr-preview -->';
+            const prNumber = Number(process.env.PR_NUMBER);
+            const version = process.env.PREVIEW_VERSION;
+            const body = `${marker}
+            🚀 CLI preview published: \`socketsecurity==${version}\`
 
-            const botComment = comments.data.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('🚀 Preview package published!')
-            );
-
-            const comment = `
-            🚀 Preview package published!
-
-            Install with:
             \`\`\`bash
             pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple socketsecurity==${version}
             \`\`\`
 
-            Docker image: \`socketdev/cli:pr-${prNumber}\`
-            `;
-
-            if (botComment) {
-              // Update existing comment
+            TestPyPI's package index can take several minutes to expose a newly uploaded version.`;
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(comment =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+            if (existing) {
               await github.rest.issues.updateComment({
-                owner: owner,
-                repo: repo,
-                comment_id: botComment.id,
-                body: comment
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
               });
             } else {
-              // Create new comment
               await github.rest.issues.createComment({
-                owner: owner,
-                repo: repo,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
                 issue_number: prNumber,
-                body: comment
+                body,
               });
             }
 
-      - name: Verify package is available
-        if: steps.version_check.outputs.exists != 'true'
-        id: verify_package
-        env:
-          VERSION: ${{ env.VERSION }}
-        run: |
-          for i in {1..30}; do
-            if pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple socketsecurity==${VERSION}; then
-              echo "Package ${VERSION} is now available and installable on Test PyPI"
-              pip uninstall -y socketsecurity
-              echo "success=true" >> $GITHUB_OUTPUT
-              exit 0
-            fi
-            echo "Attempt $i: Package not yet installable, waiting 20s... (${i}/30)"
-            sleep 20
-          done
-          echo "success=false" >> $GITHUB_OUTPUT
-          exit 1
-
-      - name: Set up Docker publishing
-        if: steps.verify_package.outputs.success == 'true'
-        uses: ./.github/actions/setup-docker
+  publish-docker:
+    needs: build
+    if: >-
+      github.event.label.name == 'publish-docker-preview' ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish_docker)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', inputs.pr_number) }}
+          fetch-depth: 1
+          persist-credentials: false
 
-      - name: Build & Push Docker Preview
-        if: steps.verify_package.outputs.success == 'true'
+      - name: Download preview distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: socketsecurity-preview-${{ github.run_id }}-${{ github.run_attempt }}
+          path: dist
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker preview
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        env:
-          VERSION: ${{ env.VERSION }}
         with:
+          file: Dockerfile.preview
           push: true
-          # Preview images are for quick testing -- build amd64 only. arm64 via
-          # QEMU emulation is the slowest part of the job; release builds keep
-          # multi-arch. GHA layer cache speeds up repeated preview builds.
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: |
-            socketdev/cli:pr-${{ github.event.pull_request.number }}
+          tags: socketdev/cli:pr-${{ needs.build.outputs.pr_number }}
           build-args: |
-            CLI_VERSION=${{ env.VERSION }}
-            PIP_INDEX_URL=https://test.pypi.org/simple
-            PIP_EXTRA_INDEX_URL=https://pypi.org/simple
+            SDK_PREVIEW_VERSION=${{ inputs.sdk_preview_version }}
+
+      - name: Comment on pull request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ needs.build.outputs.pr_number }}
+        with:
+          script: |
+            const marker = '<!-- socketsecurity-docker-preview -->';
+            const prNumber = Number(process.env.PR_NUMBER);
+            const body = `${marker}
+            🐳 Docker preview published: \`socketdev/cli:pr-${prNumber}\`
+
+            This mutable tag is only created when a Docker preview is explicitly requested.`;
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(comment =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -25,27 +25,85 @@ on:
         type: string
 
 concurrency:
-  group: publish-pr-preview-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: publish-pr-preview-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
-  build:
+  context:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      ((github.event.label.name == 'publish-preview' ||
+      (github.event.label.name == 'publish-preview' ||
       github.event.label.name == 'publish-docker-preview') &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      pr_number: ${{ steps.context.outputs.pr_number }}
+      head_sha: ${{ steps.context.outputs.head_sha }}
+    steps:
+      - name: Validate pull request context
+        id: context
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          WORKFLOW_REF: ${{ github.ref }}
+        with:
+          script: |
+            const rawPrNumber = context.eventName === 'workflow_dispatch'
+              ? process.env.INPUT_PR_NUMBER
+              : process.env.EVENT_PR_NUMBER;
+            if (!/^[1-9][0-9]*$/.test(rawPrNumber || '')) {
+              core.setFailed('Pull request number must contain ASCII digits only.');
+              return;
+            }
+
+            if (context.eventName === 'workflow_dispatch') {
+              const defaultRef = `refs/heads/${process.env.DEFAULT_BRANCH}`;
+              if (process.env.WORKFLOW_REF !== defaultRef) {
+                core.setFailed(`Run manual previews from ${defaultRef}.`);
+                return;
+              }
+            }
+
+            const prNumber = Number(rawPrNumber);
+            if (!Number.isSafeInteger(prNumber)) {
+              core.setFailed('Pull request number is outside the supported range.');
+              return;
+            }
+            const {data: pullRequest} = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            if (pullRequest.state !== 'open') {
+              core.setFailed(`Pull request #${prNumber} is not open.`);
+              return;
+            }
+            if (pullRequest.head.repo?.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setFailed('Preview publication is limited to branches in this repository.');
+              return;
+            }
+
+            core.setOutput('pr_number', String(prNumber));
+            core.setOutput('head_sha', pullRequest.head.sha);
+
+  build:
+    needs: context
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
     outputs:
       preview_version: ${{ steps.version.outputs.preview_version }}
-      pr_number: ${{ steps.context.outputs.pr_number }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', inputs.pr_number) }}
+          ref: ${{ needs.context.outputs.head_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -58,13 +116,6 @@ jobs:
 
       - name: Install distribution validator
         run: python -m pip install "twine>=4.0.0"
-
-      - name: Record preview context
-        id: context
-        env:
-          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
-          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
-        run: echo "pr_number=${EVENT_PR_NUMBER:-$INPUT_PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Inject deterministic preview version
         env:
@@ -110,7 +161,7 @@ jobs:
           retention-days: 14
 
   publish-package:
-    needs: build
+    needs: [context, build]
     if: >-
       github.event.label.name == 'publish-preview' ||
       (github.event_name == 'workflow_dispatch' && inputs.publish_test_pypi)
@@ -128,7 +179,7 @@ jobs:
           path: dist
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
           verbose: true
@@ -137,7 +188,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PREVIEW_VERSION: ${{ needs.build.outputs.preview_version }}
-          PR_NUMBER: ${{ needs.build.outputs.pr_number }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
         with:
           script: |
             const marker = '<!-- socketsecurity-pr-preview -->';
@@ -176,7 +227,7 @@ jobs:
             }
 
   publish-docker:
-    needs: build
+    needs: [context, build]
     if: >-
       github.event.label.name == 'publish-docker-preview' ||
       (github.event_name == 'workflow_dispatch' && inputs.publish_docker)
@@ -188,7 +239,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', inputs.pr_number) }}
+          # Keep the Dockerfile and credential-handling action on trusted code.
+          # The pull request enters this job only through the built wheel.
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
           persist-credentials: false
 
@@ -198,29 +251,28 @@ jobs:
           name: socketsecurity-preview-${{ github.run_id }}-${{ github.run_attempt }}
           path: dist
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      - name: Set up Docker publishing
+        uses: ./.github/actions/setup-docker
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          enable-qemu: "false"
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker preview
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           file: Dockerfile.preview
           push: true
+          pull: true
           platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: socketdev/cli:pr-${{ needs.build.outputs.pr_number }}
+          tags: socketdev/cli:pr-${{ needs.context.outputs.pr_number }}
           build-args: |
             SDK_PREVIEW_VERSION=${{ inputs.sdk_preview_version }}
 
       - name: Comment on pull request
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          PR_NUMBER: ${{ needs.build.outputs.pr_number }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
         with:
           script: |
             const marker = '<!-- socketsecurity-docker-preview -->';

--- a/.hooks/sync_version.py
+++ b/.hooks/sync_version.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-import subprocess
+import json
 import pathlib
 import re
+import subprocess
 import sys
 import urllib.request
-import json
 
 INIT_FILE = pathlib.Path("socketsecurity/__init__.py")
 PYPROJECT_FILE = pathlib.Path("pyproject.toml")
@@ -125,12 +125,44 @@ def run_uv_lock() -> bool:
     after = UV_LOCK_FILE.read_bytes() if UV_LOCK_FILE.exists() else b""
     return before != after
 
+
+def read_preview_id():
+    if "--preview-id" not in sys.argv:
+        return None
+
+    option_index = sys.argv.index("--preview-id")
+    try:
+        preview_id = sys.argv[option_index + 1]
+    except IndexError:
+        print("❌ `--preview-id` requires a numeric value.")
+        sys.exit(1)
+
+    if not preview_id.isdigit():
+        print("❌ `--preview-id` must contain digits only.")
+        sys.exit(1)
+    return preview_id
+
+
 def main():
     dev_mode = "--dev" in sys.argv
+    skip_lock = "--skip-lock" in sys.argv
+    preview_id = read_preview_id()
     current_version = read_version_from_init(INIT_FILE)
     previous_version = read_version_from_git("socketsecurity/__init__.py")
 
     print(f"Current: {current_version}, Previous: {previous_version}")
+
+    if preview_id is not None:
+        if not dev_mode:
+            print("❌ `--preview-id` can only be used with `--dev`.")
+            sys.exit(1)
+        base_version = current_version.split(".dev")[0]
+        new_version = f"{base_version}.dev{preview_id}"
+        inject_version(new_version)
+        if not skip_lock:
+            run_uv_lock()
+        print(f"✅ Prepared deterministic preview version {new_version}.")
+        sys.exit(0)
 
     if current_version == previous_version:
         if dev_mode:

--- a/.hooks/sync_version.py
+++ b/.hooks/sync_version.py
@@ -137,8 +137,8 @@ def read_preview_id():
         print("❌ `--preview-id` requires a numeric value.")
         sys.exit(1)
 
-    if not preview_id.isdigit():
-        print("❌ `--preview-id` must contain digits only.")
+    if not preview_id.isascii() or not preview_id.isdigit():
+        print("❌ `--preview-id` must contain ASCII digits only.")
         sys.exit(1)
     return preview_id
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,6 @@ Before opening a pull request, run:
 
 ```bash
 make test
-make lint
 uv run hatch build
 uv run python -m twine check dist/*
 ```
@@ -45,18 +44,19 @@ needs testing:
   `socketdev/cli:pr-<pull-request-number>` image to Docker Hub and adds or
   updates a pull request comment with the image tag.
 
-Label-triggered publication is skipped for pull requests from forks. Each label
-is handled as a separate event, so applying both labels starts two workflow
-runs. Use manual dispatch instead when both artifacts should be published in a
-single run.
+Both label-triggered and manually dispatched previews are limited to open pull
+requests whose branches belong to this repository. Each label is handled as a
+separate event, so applying both labels starts two workflow runs. Use manual
+dispatch instead when both artifacts should be published in a single run.
 
 The workflow reacts when a label is added; pushing another commit while the
 label remains on the pull request does not publish a new preview. To publish the
 new pull request head or retry a failed publication, remove the relevant label
 and apply it again.
 
-Maintainers can also open **Actions > Publish PR Preview > Run workflow**, enter
-the pull request number, and choose whether to publish to TestPyPI, Docker Hub,
-or both. When testing the CLI against an SDK preview, enter the exact TestPyPI
-`socketdev` prerelease in `sdk_preview_version`; publish the SDK preview first
-and allow time for TestPyPI to expose it before starting the CLI Docker preview.
+Maintainers can also open **Actions > Publish PR Preview > Run workflow**, run
+it from the repository's default branch, enter the pull request number, and
+choose whether to publish to TestPyPI, Docker Hub, or both. When testing the CLI
+against an SDK preview, enter the exact TestPyPI `socketdev` prerelease in
+`sdk_preview_version`; publish the SDK preview first and allow time for
+TestPyPI to expose it before starting the CLI Docker preview.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+## Development setup
+
+Use Python 3.11 or newer and install
+[`uv`](https://docs.astral.sh/uv/getting-started/installation/). From the
+repository root, create the environment and install all development
+dependencies:
+
+```bash
+uv sync --all-extras
+```
+
+Before opening a pull request, run:
+
+```bash
+make test
+make lint
+uv run hatch build
+uv run python -m twine check dist/*
+```
+
+To develop against a local SDK checkout, set `SOCKET_SDK_PATH` if it is not at
+`../socketdev`, then run `make first-time-local-setup`.
+
+## Pull request validation
+
+The `Package Check` workflow runs automatically for pull requests. It builds
+and validates the distributions, smoke-tests the wheel, and uploads the
+distributions as workflow artifacts. It does not publish a package or Docker
+image.
+
+## Publishing pull request previews
+
+Preview publication is intentionally opt-in. Only request previews for code
+that is trusted to run with the repository's publishing permissions.
+
+For a pull request from this repository, apply the label for the artifact that
+needs testing:
+
+- `publish-preview` publishes a uniquely versioned `socketsecurity` prerelease
+  to TestPyPI and adds or updates a pull request comment with the exact version
+  and installation command.
+- `publish-docker-preview` publishes the mutable
+  `socketdev/cli:pr-<pull-request-number>` image to Docker Hub and adds or
+  updates a pull request comment with the image tag.
+
+Label-triggered publication is skipped for pull requests from forks. Each label
+is handled as a separate event, so applying both labels starts two workflow
+runs. Use manual dispatch instead when both artifacts should be published in a
+single run.
+
+The workflow reacts when a label is added; pushing another commit while the
+label remains on the pull request does not publish a new preview. To publish the
+new pull request head or retry a failed publication, remove the relevant label
+and apply it again.
+
+Maintainers can also open **Actions > Publish PR Preview > Run workflow**, enter
+the pull request number, and choose whether to publish to TestPyPI, Docker Hub,
+or both. When testing the CLI against an SDK preview, enter the exact TestPyPI
+`socketdev` prerelease in `sdk_preview_version`; publish the SDK preview first
+and allow time for TestPyPI to expose it before starting the CLI Docker preview.

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,14 +115,22 @@ RUN curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/p
 RUN if [ "$USE_LOCAL_INSTALL" = "true" ]; then \
         echo "Using local development install"; \
     else \
+        cli_installed=false; \
         for i in $(seq 1 10); do \
             echo "Attempt $i/10: Installing socketsecurity==$CLI_VERSION"; \
             if pip install --index-url ${PIP_INDEX_URL} --extra-index-url ${PIP_EXTRA_INDEX_URL} socketsecurity==$CLI_VERSION; then \
+                cli_installed=true; \
                 break; \
             fi; \
-            echo "Install failed, waiting 30s before retry..."; \
-            sleep 30; \
-        done && \
+            if [ "$i" -lt 10 ]; then \
+                echo "Install failed, waiting 30s before retry..."; \
+                sleep 30; \
+            fi; \
+        done; \
+        if [ "$cli_installed" != "true" ]; then \
+            echo "Failed to install socketsecurity==$CLI_VERSION after 10 attempts"; \
+            exit 1; \
+        fi; \
         if [ ! -z "$SDK_VERSION" ]; then \
             pip install --index-url ${PIP_INDEX_URL} --extra-index-url ${PIP_EXTRA_INDEX_URL} socketdev==${SDK_VERSION}; \
         fi; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -141,7 +141,6 @@ COPY . /app
 WORKDIR /app
 RUN if [ "$USE_LOCAL_INSTALL" = "true" ]; then \
         pip install --upgrade -e .; \
-        pip install --upgrade socketdev; \
     fi
 
 # Create workspace directory with proper permissions

--- a/Dockerfile.preview
+++ b/Dockerfile.preview
@@ -1,0 +1,23 @@
+FROM socketdev/cli:latest
+
+ARG SDK_PREVIEW_VERSION=""
+ARG PIP_INDEX_URL=https://test.pypi.org/simple/
+ARG PIP_EXTRA_INDEX_URL=https://pypi.org/simple/
+
+COPY dist/socketsecurity-*.whl /tmp/socket-preview/
+
+RUN set -eux; \
+    if [ -n "$SDK_PREVIEW_VERSION" ]; then \
+        pip install \
+            --no-cache-dir \
+            --index-url "$PIP_INDEX_URL" \
+            --extra-index-url "$PIP_EXTRA_INDEX_URL" \
+            "socketdev==$SDK_PREVIEW_VERSION"; \
+    fi; \
+    pip install \
+        --no-cache-dir \
+        --no-deps \
+        --force-reinstall \
+        /tmp/socket-preview/socketsecurity-*.whl; \
+    socketcli --help >/dev/null; \
+    rm -rf /tmp/socket-preview

--- a/Dockerfile.preview
+++ b/Dockerfile.preview
@@ -1,23 +1,68 @@
+# syntax=docker/dockerfile:1
+
 FROM socketdev/cli:latest
 
 ARG SDK_PREVIEW_VERSION=""
-ARG PIP_INDEX_URL=https://test.pypi.org/simple/
-ARG PIP_EXTRA_INDEX_URL=https://pypi.org/simple/
+ARG PYPI_INDEX_URL=https://pypi.org/simple/
+ARG TEST_PYPI_INDEX_URL=https://test.pypi.org/simple/
 
 COPY dist/socketsecurity-*.whl /tmp/socket-preview/
 
-RUN set -eux; \
-    if [ -n "$SDK_PREVIEW_VERSION" ]; then \
-        pip install \
-            --no-cache-dir \
-            --index-url "$PIP_INDEX_URL" \
-            --extra-index-url "$PIP_EXTRA_INDEX_URL" \
-            "socketdev==$SDK_PREVIEW_VERSION"; \
-    fi; \
-    pip install \
+RUN <<'SH'
+set -eux
+
+wheel=$(find /tmp/socket-preview -maxdepth 1 -name 'socketsecurity-*.whl' -print -quit)
+
+# Resolve every wheel dependency from production PyPI. When an exact SDK
+# preview is requested, leave socketdev out so the prerelease can intentionally
+# override a final-version floor such as socketdev>=3.4.0.
+python - "$wheel" > /tmp/socket-preview/requirements.txt <<'PY'
+import email
+import os
+import sys
+import zipfile
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+wheel_path = sys.argv[1]
+with zipfile.ZipFile(wheel_path) as archive:
+    metadata_path = next(
+        name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+    )
+    metadata = email.message_from_bytes(archive.read(metadata_path))
+
+sdk_preview = os.environ.get("SDK_PREVIEW_VERSION")
+for value in metadata.get_all("Requires-Dist", []):
+    if sdk_preview and canonicalize_name(Requirement(value).name) == "socketdev":
+        continue
+    print(value)
+PY
+
+python -m pip install \
+    --no-cache-dir \
+    --index-url "$PYPI_INDEX_URL" \
+    --requirement /tmp/socket-preview/requirements.txt
+
+if [ -n "$SDK_PREVIEW_VERSION" ]; then
+    mkdir /tmp/socket-preview/sdk
+    python -m pip download \
         --no-cache-dir \
         --no-deps \
-        --force-reinstall \
-        /tmp/socket-preview/socketsecurity-*.whl; \
-    socketcli --help >/dev/null; \
-    rm -rf /tmp/socket-preview
+        --dest /tmp/socket-preview/sdk \
+        --index-url "$TEST_PYPI_INDEX_URL" \
+        "socketdev==$SDK_PREVIEW_VERSION"
+    python -m pip install \
+        --no-cache-dir \
+        --index-url "$PYPI_INDEX_URL" \
+        /tmp/socket-preview/sdk/socketdev-*.whl
+fi
+
+python -m pip install \
+    --no-cache-dir \
+    --no-deps \
+    --force-reinstall \
+    "$wheel"
+socketcli --help >/dev/null
+rm -rf /tmp/socket-preview
+SH


### PR DESCRIPTION
## Summary

Replace the always-on TestPyPI and Docker preview pipeline with deterministic local package validation plus explicitly requested publication:

- `Package Check` runs on every PR and on `main`. It builds the wheel and sdist, validates them with Twine, installs the wheel without resolving dependencies, verifies its entry point and metadata, compiles the package, and uploads the distributions as workflow artifacts.
- `Publish PR Preview` publishes to TestPyPI only through the `publish-preview` label or manual workflow dispatch.
- Docker previews publish only through the separate `publish-docker-preview` label or the manual `publish_docker` input.

This follows the same pattern as SocketDev/socket-sdk-python#100.

## Why

The previous required-on-every-push pipeline mixed package validation, TestPyPI propagation, and a heavyweight Docker deployment. TestPyPI's cached Simple API could make the job wait for ten minutes and fail after the upload had already succeeded. Every PR also pushed a mutable `pr-<number>` Docker Hub tag, creating repository clutter even when nobody needed an image.

## Implementation

- Preview versions use a unique `.dev<run-id-and-attempt>` suffix instead of querying TestPyPI for the next free number.
- Preview version injection can skip `uv lock`, so artifact construction is not coupled to dependency resolution.
- The TestPyPI verification loop is removed; distributions are built, checked, and inspected locally before the trusted upload.
- Docker previews use a small `Dockerfile.preview` overlay based on `socketdev/cli:latest`, installing the locally built PR wheel rather than waiting for TestPyPI and rebuilding Go, Java, .NET, Rust, and other toolchains.
- Manual Docker previews accept an optional exact `socketdev` TestPyPI prerelease for cross-repository integration testing.
- The production Dockerfile now exits nonzero if all ten CLI installation attempts fail instead of continuing after the final sleep.
- The dependency-review Dockerfile smoke uses the intended local-install mode instead of relying on an empty `CLI_VERSION` install being swallowed.

## Opt-in usage

Use these existing repository labels:

- `publish-preview` — publish the Python package to TestPyPI.
- `publish-docker-preview` — publish `socketdev/cli:pr-<number>` to Docker Hub.

Maintainers can alternatively run **Publish PR Preview** manually, choose TestPyPI and/or Docker publication, and optionally supply an SDK preview version.

## Review follow-up

- Manual dispatch now validates an ASCII numeric PR number, requires the default branch, rejects closed and fork PRs, and pins the exact PR head SHA before any checkout.
- Docker publishing checks out the trusted default branch for the overlay and credential-handling action; PR code enters that job only as the already-built wheel artifact.
- The Docker overlay resolves runtime dependencies from production PyPI, downloads only an explicitly requested SDK prerelease from TestPyPI, always refreshes the base image, and avoids exporting a low-value GHA cache.
- The preview ID guard now accepts ASCII digits only, the PyPI publisher action is aligned with the SDK, and the unconstrained Docker SDK upgrade was removed.
- CONTRIBUTING documents the same-repository and default-branch requirements.

## Validation

- `actionlint .github/workflows/package-check.yml .github/workflows/pr-preview.yml`
- `ruff check .hooks/sync_version.py`
- Wheel and sdist built successfully and passed `twine check`
- Wheel installed without dependencies and passed metadata, entry-point, and bytecode checks
- Deterministic preview version injection verified without changing `uv.lock`
- `Dockerfile.preview` built successfully against `socketdev/cli:latest`; after the initial base pull, the PR-specific install and CLI smoke layer completed in about one second

The existing unit and E2E workflows remain responsible for dependency resolution and behavioral testing. After this merges, `Package Check` can be added to the branch-protection required checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI publishing gates and release-preview mechanics (TestPyPI/Docker secrets on label/dispatch only); runtime product code is largely untouched aside from Dockerfile install failure handling.
> 
> **Overview**
> **Every PR** now gets a **Package Check** workflow that builds wheel/sdist, runs `twine check`, smoke-installs the wheel (entry point + bytecode), and uploads artifacts—**without** publishing.
> 
> **TestPyPI and Docker previews** move to **Publish PR Preview**, triggered only by `publish-preview` / `publish-docker-preview` labels (in-repo PRs) or manual dispatch—not on every push. Preview versions use a deterministic `.dev<run-id>` suffix via new `--preview-id` / `--skip-lock` flags on `sync_version.py`, dropping TestPyPI “next free version” queries and the post-upload install wait loop.
> 
> **Docker previews** use a new **`Dockerfile.preview`** overlay on `socketdev/cli:latest` that installs the built PR wheel locally (optional `socketdev` TestPyPI prerelease), instead of rebuilding the full image from TestPyPI.
> 
> The production **Dockerfile** now **fails the build** if all ten PyPI install attempts fail; dependency-review’s Dockerfile smoke passes **`USE_LOCAL_INSTALL=true`**. **CONTRIBUTING.md** documents validation vs opt-in preview labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73504a668ff8ca7c9ab7fbca0a22150c6bba9f8c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
