### PR TITLE
Harden PyPI install verification against stale cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,10 @@ jobs:
           VERSION: ${{ env.VERSION }}
         run: |
           # The first lookup can race PyPI's Simple-index propagation, and a delayed
-          # CDN purge can leave the index stale for 10+ minutes after a successful
-          # upload (socketsecurity 2.5.9 and socketdev 3.4.2 both hit this on
-          # 2026-08-05). pip caches HTTP responses by default, so without
-          # --no-cache-dir every retry can reuse that initial stale response instead
-          # of checking whether the release has appeared. Budget: 30 minutes.
+          # CDN purge can leave the index stale well after a successful upload.
+          # pip caches HTTP responses by default, so without --no-cache-dir every
+          # retry can reuse that initial stale response instead of checking whether
+          # the release has appeared. Budget: 30 minutes.
           MAX_ATTEMPTS=60
           for i in $(seq 1 "$MAX_ATTEMPTS"); do
             if python -m pip install \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,15 +79,23 @@ jobs:
         env:
           VERSION: ${{ env.VERSION }}
         run: |
-          for i in {1..30}; do
-            if pip install socketsecurity==${VERSION}; then
+          # PyPI's simple index is CDN-cached and can lag a successful upload
+          # by 10+ minutes when a cache purge is delayed (both socketsecurity
+          # 2.5.9 and socketdev 3.4.2 hit this on 2026-08-05), so retry for up
+          # to 30 minutes and use --no-cache-dir so each attempt refetches the
+          # index instead of revalidating a stale copy from pip's HTTP cache.
+          for i in {1..60}; do
+            if pip install --no-cache-dir socketsecurity==${VERSION}; then
               echo "Package ${VERSION} is now available and installable on PyPI"
               pip uninstall -y socketsecurity
               echo "success=true" >> $GITHUB_OUTPUT
               exit 0
             fi
-            echo "Attempt $i: Package not yet installable, waiting 20s... (${i}/30)"
-            sleep 20
+            if curl -s -f "https://pypi.org/pypi/socketsecurity/${VERSION}/json" > /dev/null; then
+              echo "Release ${VERSION} exists on PyPI (JSON API) but is not in the simple index yet - CDN propagation delay"
+            fi
+            echo "Attempt $i: Package not yet installable, waiting 30s... (${i}/60)"
+            sleep 30
           done
           echo "success=false" >> $GITHUB_OUTPUT
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,25 +79,32 @@ jobs:
         env:
           VERSION: ${{ env.VERSION }}
         run: |
-          # PyPI's simple index is CDN-cached and can lag a successful upload
-          # by 10+ minutes when a cache purge is delayed (both socketsecurity
-          # 2.5.9 and socketdev 3.4.2 hit this on 2026-08-05), so retry for up
-          # to 30 minutes and use --no-cache-dir so each attempt refetches the
-          # index instead of revalidating a stale copy from pip's HTTP cache.
-          for i in {1..60}; do
-            if pip install --no-cache-dir socketsecurity==${VERSION}; then
+          # The first lookup can race PyPI's Simple-index propagation, and a delayed
+          # CDN purge can leave the index stale for 10+ minutes after a successful
+          # upload (socketsecurity 2.5.9 and socketdev 3.4.2 both hit this on
+          # 2026-08-05). pip caches HTTP responses by default, so without
+          # --no-cache-dir every retry can reuse that initial stale response instead
+          # of checking whether the release has appeared. Budget: 30 minutes.
+          MAX_ATTEMPTS=60
+          for i in $(seq 1 "$MAX_ATTEMPTS"); do
+            if python -m pip install \
+              --no-cache-dir \
+              --index-url https://pypi.org/simple/ \
+              "socketsecurity==${VERSION}"; then
               echo "Package ${VERSION} is now available and installable on PyPI"
-              pip uninstall -y socketsecurity
-              echo "success=true" >> $GITHUB_OUTPUT
+              python -m pip uninstall -y socketsecurity
+              echo "success=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             if curl -s -f "https://pypi.org/pypi/socketsecurity/${VERSION}/json" > /dev/null; then
-              echo "Release ${VERSION} exists on PyPI (JSON API) but is not in the simple index yet - CDN propagation delay"
+              echo "Release ${VERSION} exists on PyPI (JSON API) but is not in the Simple index yet - CDN propagation delay"
             fi
-            echo "Attempt $i: Package not yet installable, waiting 30s... (${i}/60)"
-            sleep 30
+            if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Attempt $i: Package not yet installable, waiting 30s... (${i}/${MAX_ATTEMPTS})"
+              sleep 30
+            fi
           done
-          echo "success=false" >> $GITHUB_OUTPUT
+          echo "success=false" >> "$GITHUB_OUTPUT"
           exit 1
 
       - name: Build & Push Docker


### PR DESCRIPTION
## Summary

The release workflow's "Verify package is installable" step retries `pip install socketsecurity==$VERSION` for 10 minutes (30 × 20s). That budget assumed PyPI's simple index reflects a successful upload within seconds, which held until 2026-08-05, when two releases in one day exceeded it:

- `socketsecurity` 2.5.9 — uploaded 16:40:20 UTC; all 30 verify attempts (16:40:35–16:50:46) got a version list ending at 2.5.8. The release run failed and the Docker publish was skipped, so `socketdev/cli:2.5.9` was never pushed.
- `socketdev` 3.4.2 — uploaded 23:29:39 UTC; same failure 23:30–23:39 in that repo's identical verify step. Meanwhile other CI runners installed 3.4.2 from PyPI successfully during the same minutes, so the staleness was specific to individual CDN cache nodes.

In both cases the JSON API (`/pypi/<pkg>/<version>/json`) showed the release immediately; only the CDN-cached simple index (`/simple/<pkg>/`, which pip actually uses) was stale. PyPI's status page reported no incident. This failure class has recurred on PyPI's side for years (see references below).

## Changes

- Extend the retry window from 10 to 30 minutes (60 × 30s), with no sleep after the final attempt.
- Add `--no-cache-dir` so each attempt fully refetches the index. The simple index is served with `Cache-Control: max-age=600`, so without this, pip revalidates its locally cached copy by ETag and a stale CDN node can keep answering 304 for the whole loop.
- Install via `python -m pip` with an explicit `--index-url https://pypi.org/simple/`, and quote workflow output redirects.
- On failed attempts, check the JSON API and log when the version exists there — making "index propagation delay" distinguishable from "publish actually failed" in the logs.

The verify step is now line-for-line consistent with the same hardening in SocketDev/socket-sdk-python#102.

## Notes

- Rerunning the failed v2.5.9 release run after this propagation delay cleared will publish the missing Docker images; the workflow's existing `pypi_exists` check makes the rerun idempotent.

## References

Prior reports of the same PyPI simple-index staleness class:
- pypi/warehouse#17179 — PyPI caching packages too long (release not in index hours after upload)
- pypi/warehouse#8416 — New packages not appearing in pypi.org/simple index
- pypi/warehouse#5017 — New packages not appearing in pypi.org/simple index