### PR TITLE
feat(user-agent): rename the client to socket-python-cli

### DIFF
--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,6 @@
 __author__ = 'socket.dev'
 __version__ = '2.6.8'
-USER_AGENT = f'SocketPythonCLI/{__version__}'
+# The name Socket's API attributes this client by. Callers that build their
+# own User-Agent read it from here, so a rename lands in one place.
+USER_AGENT_NAME = 'socket-python-cli'
+USER_AGENT = f'{USER_AGENT_NAME}/{__version__}'

--- a/socketsecurity/socketcli.py
+++ b/socketsecurity/socketcli.py
@@ -11,6 +11,7 @@ from git import InvalidGitRepositoryError, NoSuchPathError
 from socketdev import socketdev
 from socketdev.fullscans import FullScanParams
 
+from socketsecurity import USER_AGENT_NAME
 from socketsecurity.config import CliConfig
 from socketsecurity.core import Core
 from socketsecurity.core.classes import Diff
@@ -108,7 +109,7 @@ def get_api_request_timeout(config: CliConfig) -> int:
 
 
 def build_socket_sdk(config: CliConfig) -> socketdev:
-    cli_user_agent_string = f"SocketPythonCLI/{config.version}"
+    cli_user_agent_string = f"{USER_AGENT_NAME}/{config.version}"
     return socketdev(
         token=config.api_token,
         timeout=get_api_request_timeout(config),


### PR DESCRIPTION
Socket's public APIs read the User-Agent to attribute a request, and every other Socket client names itself in lowercase-hyphen form. This renames `SocketPythonCLI/` to `socket-python-cli/` and collapses the two copies of the name into one constant.

<details>
<summary>Why one constant</summary>

The name was a literal in two places: `socketsecurity/__init__.py` built `USER_AGENT` from it, and `build_socket_sdk` in `socketsecurity/socketcli.py` rebuilt the same string by hand for the SDK's `user_agent` override. A rename could half-apply and leave the CLI reporting two different names depending on the call path.

Both now read `USER_AGENT_NAME` from `socketsecurity/__init__.py`. `config.version` already defaults to `__version__`, so the SDK override keeps reporting exactly what it did before.
</details>

<details>
<summary>Rollout</summary>

There is no coordination needed. Socket's API-side attribution already accepts the old and the new name both, so the rename carries across with no gap and nothing breaks whether this ships first or second.

Both changed files parse (`python3 -m ast`), and no occurrence of the old name remains in the repo.
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only User-Agent string change with no auth or scan logic touched; API attribution is described as accepting both old and new names.
> 
> **Overview**
> Renames the Python CLI’s **User-Agent client identifier** from `SocketPythonCLI/` to **`socket-python-cli/`**, matching Socket’s lowercase-hyphen convention for API attribution.
> 
> Introduces **`USER_AGENT_NAME`** in `socketsecurity/__init__.py` and builds **`USER_AGENT`** from it, so the SDK setup in `build_socket_sdk` no longer duplicates a hardcoded name and stays consistent with `CliClient` headers that already read `USER_AGENT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d79c2642e83329eba5910cc8b93e8713176ca4cd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->