### PR TITLE
Fix pull request comment rendering and disable flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@
   once per ignore command, and an ignore-all comment produces none, so no rows
   were removed.
 
+### Fixed: `--disable-security-issue` and `--disable-overview` now suppress the comment entirely
+
+- Both flags were checked only after testing whether a comment of that type was
+  already on the pull request, so they suppressed the first post and then
+  updated that comment on every later run. `--disable-security-issue` in
+  particular kept refreshing an existing comment with the full alerts table.
+- The flags now mean the CLI does not manage that comment at all. An existing
+  comment is left untouched rather than being rewritten, since a body claiming
+  no alerts would be inaccurate when reporting is merely switched off.
+- The decision moved into `should_write_comment()` so it is covered directly by
+  tests.
+
 ## 2.6.11
 
 ### Changed: bump pinned @coana-tech/cli to 15.10.32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.6.12
+## 2.7.0
 
 ### Fixed: unreadable reachability facts no longer report a blocking package
 
@@ -17,6 +17,27 @@
 - Each placeholder is written to its own temporary directory. Two CLI runs sharing a
   temporary directory previously used the same path and could remove each other's
   placeholder mid-upload.
+
+### Fixed: pull request comments no longer show orphaned tags or an empty table
+
+- Optional sections that rendered as empty, such as the ignore instructions
+  suppressed by `--disable-ignore`, left a whitespace-only line in the alerts
+  table. That line closed the surrounding HTML block, and the indented
+  `</blockquote></details>` tags after it were rendered as a literal code block.
+  Generated comment markup now omits blank lines and stays under the indentation
+  that starts a code block.
+- Alert descriptions, suggestions and license findings are collapsed onto a
+  single line so multi-line API text cannot break the table markup either.
+- When a pull request has no alerts left to report, the security comment is
+  replaced with a short confirmation instead of keeping the "Caution" banner
+  above a table with no rows. This happens both when a later commit resolves
+  every alert and when every alert is ignored by comment. The comment marker is
+  preserved, so a commit that reintroduces an alert updates the same comment
+  rather than posting a second one.
+- `@SocketSecurity ignore-all` now applies to comments written by CLI versions
+  before 2.0.55, which use the older Markdown alerts table. The check was made
+  once per ignore command, and an ignore-all comment produces none, so no rows
+  were removed.
 
 ## 2.6.11
 
@@ -49,7 +70,6 @@
 - Bumped the pinned reachability engine (`@coana-tech/cli`) from `15.10.23` to
   `15.10.25`. See the [Coana changelogs](https://docs.coana.tech/changelogs) for
   engine changes.
-
 ## 2.6.7
 
 ### Changed: bump pinned @coana-tech/cli to 15.10.23

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.6.12"
+version = "2.7.0"
 requires-python = ">= 3.11"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.6.12'
+__version__ = '2.7.0'
 USER_AGENT = f'SocketPythonCLI/{__version__}'

--- a/socketsecurity/core/messages.py
+++ b/socketsecurity/core/messages.py
@@ -806,6 +806,90 @@ class Messages:
 
         return gitlab_report
 
+    # A blank line terminates a CommonMark HTML block. When that happens inside
+    # the alerts table the closing tags that follow are no longer treated as
+    # markup, and because they are indented four or more spaces they render as a
+    # literal code block containing `</blockquote></details>` instead.
+    MAX_HTML_INDENT = 3
+
+    @staticmethod
+    def inline_html_text(value) -> str:
+        """
+        Collapses API supplied text onto a single line.
+
+        Alert descriptions and suggestions are interpolated into the comment HTML,
+        so an embedded newline would otherwise be able to close the surrounding
+        HTML block early.
+
+        :param value: The value to flatten. ``None`` becomes an empty string.
+        :return: str - The value with all whitespace runs collapsed to a single space.
+        """
+        if value is None:
+            return ""
+        return " ".join(str(value).split())
+
+    @staticmethod
+    def normalize_comment_html(comment: str) -> str:
+        """
+        Makes generated comment markup safe for the CommonMark renderers used by
+        GitHub and GitLab.
+
+        Drops whitespace-only lines (an optional section that rendered as empty
+        leaves one behind) and caps indentation below the four spaces that would
+        start an indented code block. Intentional separators - lines that are
+        genuinely empty - are preserved so markdown blocks still break apart.
+
+        :param comment: str - The generated comment body.
+        :return: str - The comment body with unrenderable whitespace removed.
+        """
+        lines = []
+        for line in comment.split("\n"):
+            if line and not line.strip():
+                continue
+            stripped = line.lstrip()
+            indent = min(len(line) - len(stripped), Messages.MAX_HTML_INDENT)
+            lines.append(" " * indent + stripped)
+        return "\n".join(lines)
+
+    @staticmethod
+    def security_comment_no_alerts_template(view_report_url: str = "") -> str:
+        """
+        Generates the body used when there is nothing left to report.
+
+        Alerts raised on an early commit are frequently resolved later in the same
+        pull request. Rewriting the comment to this body keeps the Socket comment
+        in place - so a later commit that reintroduces an alert updates it rather
+        than posting a second comment - without leaving the "Caution" banner above
+        an empty alerts table.
+
+        :param view_report_url: str - Optional link to the full Socket report.
+        :return: str - The formatted Markdown/HTML string.
+        """
+        lines = [
+            "<!-- socket-security-comment-actions -->",
+            "",
+            "> **✅ Socket Security**  ",
+            "> No dependency alerts to report. Any alerts previously reported on this "
+            "pull request have been resolved or ignored.",
+        ]
+        if view_report_url:
+            lines += ["", f"[View full report]({view_report_url})"]
+        return "\n".join(lines) + "\n"
+
+    @staticmethod
+    def get_view_report_url(diff: Diff) -> str:
+        """
+        Resolves the report link for a diff, preferring the PR/MR diff view.
+
+        :param diff: Diff - Diff report to pull the URL from.
+        :return: str - The report URL, or an empty string when neither is set.
+        """
+        if getattr(diff, "diff_url", None):
+            return diff.diff_url
+        if getattr(diff, "report_url", None):
+            return diff.report_url
+        return ""
+
     @staticmethod
     def security_comment_template(diff: Diff, config=None) -> str:
         """
@@ -819,7 +903,7 @@ class Messages:
         # Group license policy violations by PURL (ecosystem/package@version)
         license_groups = {}
         security_alerts = []
-        
+
         for alert in diff.new_alerts:
             if alert.type == "licenseSpdxDisj":
                 purl_key = f"{alert.pkg_type}/{alert.pkg_name}@{alert.pkg_version}"
@@ -828,6 +912,13 @@ class Messages:
                 license_groups[purl_key].append(alert)
             else:
                 security_alerts.append(alert)
+
+        view_report_url = Messages.get_view_report_url(diff)
+
+        # Without this the caution banner would sit above a table with no rows,
+        # which is how a comment looks once every alert it raised is resolved.
+        if not security_alerts and not license_groups:
+            return Messages.security_comment_no_alerts_template(view_report_url)
 
         # Start of the comment
         comment = """<!-- socket-security-comment-actions -->
@@ -875,15 +966,15 @@ class Messages:
   </td>
   <td>
     <details {details_open}>
-      <summary>{alert.pkg_name}@{alert.pkg_version} - {alert.title}</summary>
-      <p><strong>Note:</strong> {alert.description}</p>
+      <summary>{alert.pkg_name}@{alert.pkg_version} - {Messages.inline_html_text(alert.title)}</summary>
+      <p><strong>Note:</strong> {Messages.inline_html_text(alert.description)}</p>
       <p><strong>Source:</strong> <a href="{manifest_url}">Manifest File</a></p>
       <p>ℹ️ Read more on:
       <a href="{alert.purl}">This package</a> |
       <a href="{alert.url}">This alert</a> |
       <a href="https://socket.dev/alerts/malware">What is known malware?</a></p>
       <blockquote>
-        <p><em>Suggestion:</em> {alert.suggestion}</p>
+        <p><em>Suggestion:</em> {Messages.inline_html_text(alert.suggestion)}</p>
         {ignore_html}
       </blockquote>
     </details>
@@ -917,7 +1008,7 @@ class Messages:
       <ul>
 """
             for finding in license_findings:
-                comment += f"        <li>{finding}</li>\n"
+                comment += f"        <li>{Messages.inline_html_text(finding)}</li>\n"
             
             
             # Generate proper manifest URL for license violations
@@ -944,13 +1035,6 @@ class Messages:
     """
 
         # Close table
-        # Use diff_url for PRs, report_url for non-PR scans
-        view_report_url = ""
-        if hasattr(diff, 'diff_url') and diff.diff_url:
-            view_report_url = diff.diff_url
-        elif hasattr(diff, 'report_url') and diff.report_url:
-            view_report_url = diff.report_url
-            
         comment += f"""
   </tbody>
 </table>
@@ -959,7 +1043,7 @@ class Messages:
 [View full report]({view_report_url}?action=error%2Cwarn)
     """
 
-        return comment
+        return Messages.normalize_comment_html(comment)
 
     @staticmethod
     def get_severity_icon(severity: str) -> str:

--- a/socketsecurity/core/scm_comments.py
+++ b/socketsecurity/core/scm_comments.py
@@ -1,12 +1,16 @@
 import json
+import re
 
 from requests import Response
 
 from socketsecurity.core import log
 from socketsecurity.core.classes import Comment, Issue
+from socketsecurity.core.messages import Messages
 
 
 class Comments:
+    VIEW_REPORT_PATTERN = re.compile(r"\[View full report\]\(([^)\s]+)\)")
+
     @staticmethod
     def process_response(response: Response) -> dict:
         output = {}
@@ -85,6 +89,20 @@ class Comments:
         return is_heading_line
 
     @staticmethod
+    def extract_report_url(body: str) -> str:
+        """
+        Pulls the Socket report link out of an existing comment body so it can be
+        carried over when the comment is rewritten.
+
+        :param body: str - The existing comment body.
+        :return: str - The report URL without its query string, or "" if absent.
+        """
+        match = Comments.VIEW_REPORT_PATTERN.search(body)
+        if not match:
+            return ""
+        return match.group(1).split("?", 1)[0]
+
+    @staticmethod
     def process_security_comment(comment: Comment, comments) -> str:
         ignore_all, ignore_commands = Comments.get_ignore_options(comments)
         if "start-socket-alerts-table" in "".join(comment.body_list):
@@ -102,6 +120,7 @@ class Comments:
     ) -> str:
         start = False
         lines = []
+        kept_alert = False
         for line in comment.body_list:
             line = line.strip()
             if "start-socket-alerts-table" in line:
@@ -114,17 +133,25 @@ class Comments:
                 ecosystem = ecosystem.lstrip("[")
                 pkg_name, pkg_version = details.split("@")
                 pkg_name = f"{ecosystem}/{pkg_name}"
-                ignore = False
-                for name, version in ignore_commands:
-                    if ignore_all or Comments.is_ignore(pkg_name, pkg_version, name, version):
-                        ignore = True
+                # ignore_all has to be checked outside the loop: an ignore-all
+                # comment produces no ignore_commands, so a loop-internal check
+                # never runs and every row was kept.
+                ignore = ignore_all or any(
+                    Comments.is_ignore(pkg_name, pkg_version, name, version)
+                    for name, version in ignore_commands
+                )
                 if not ignore:
+                    kept_alert = True
                     lines.append(line)
             elif "end-socket-alerts-table" in line:
                 start = False
                 lines.append(line)
             else:
                 lines.append(line)
+        if not kept_alert:
+            return Messages.security_comment_no_alerts_template(
+                Comments.extract_report_url("\n".join(comment.body_list))
+            )
         return "\n".join(lines)
 
     @staticmethod
@@ -145,17 +172,21 @@ class Comments:
         """
         lines = []
         ignore_section = False
+        kept_alert = False  # Whether any alert row survived the ignore commands
         pkg_name = pkg_version = ""  # Track current package and version
 
         # Loop through the comment lines
         for line in comment.body_list:
-            line = line.strip()
+            # Match on the stripped line but keep the original, so the markup is
+            # rewritten with the same indentation it was generated with.
+            line = line.rstrip("\r")
+            stripped = line.strip()
 
             # Detect the start of an alert section
-            if line.startswith("<!-- start-socket-alert-"):
+            if stripped.startswith("<!-- start-socket-alert-"):
                 # Extract package name and version from the comment
                 try:
-                    start_marker = line[len("<!-- start-socket-alert-"):-4]  # Strip the comment markers
+                    start_marker = stripped[len("<!-- start-socket-alert-"):-4]  # Strip the comment markers
                     pkg_name, pkg_version = start_marker.split("@")  # Extract pkg_name and pkg_version
                 except ValueError:
                     pkg_name, pkg_version = "", ""
@@ -168,10 +199,11 @@ class Comments:
 
                 # If not ignored, include this start marker
                 if not ignore_section:
+                    kept_alert = True
                     lines.append(line)
 
             # Detect the end of an alert section
-            elif line.startswith("<!-- end-socket-alert-"):
+            elif stripped.startswith("<!-- end-socket-alert-"):
                 # Only include if we are not ignoring this section
                 if not ignore_section:
                     lines.append(line)
@@ -181,7 +213,14 @@ class Comments:
             elif not ignore_section:
                 lines.append(line)
 
-        return "\n".join(lines)
+        # Every row was ignored, so drop the table rather than leaving the caution
+        # banner sitting above an empty one.
+        if not kept_alert:
+            return Messages.security_comment_no_alerts_template(
+                Comments.extract_report_url("\n".join(comment.body_list))
+            )
+
+        return Messages.normalize_comment_html("\n".join(lines))
 
     @staticmethod
     def extract_alert_details_from_row(row: str, ignore_all: bool, ignore_commands: list[tuple[str, str]]) -> tuple:

--- a/socketsecurity/socketcli.py
+++ b/socketsecurity/socketcli.py
@@ -107,6 +107,27 @@ def get_api_request_timeout(config: CliConfig) -> int:
     return config.timeout if config.timeout is not None else DEFAULT_API_TIMEOUT
 
 
+def should_write_comment(disabled: bool, has_findings: bool, update_existing: bool) -> bool:
+    """
+    Decides whether a Socket comment should be written for this run.
+
+    :param disabled: bool - The comment type is switched off by flag.
+    :param has_findings: bool - There is something to report this run.
+    :param update_existing: bool - A comment of this type is already on the PR.
+    :return: bool - True when the comment should be posted or updated.
+    """
+    if disabled:
+        # The flag means the CLI does not manage this comment at all. Checking
+        # update_existing first only suppressed the very first post, so any
+        # comment already on the pull request kept being updated.
+        return False
+    if not has_findings:
+        # Nothing to report: refresh an existing comment so a resolved alerts
+        # table is cleared, but do not open a new one.
+        return update_existing
+    return True
+
+
 def build_socket_sdk(config: CliConfig) -> socketdev:
     cli_user_agent_string = f"SocketPythonCLI/{config.version}"
     return socketdev(
@@ -780,9 +801,6 @@ def main_code():
                 
                 security_comment = Messages.security_comment_template(diff, config)
                 
-                new_security_comment = True
-                new_overview_comment = True
-                
                 update_old_security_comment = (
                     security_comment is None or
                     security_comment == "" or
@@ -795,20 +813,22 @@ def main_code():
                     (len(comments) != 0 and comments.get("overview") is not None)
                 )
                 
-                if len(diff.new_alerts) == 0 or config.disable_security_issue:
-                    if not update_old_security_comment:
-                        new_security_comment = False
-                        log.debug("No new alerts or security issue comment disabled")
-                    else:
-                        log.debug("Updated security comment with no new alerts")
-                
+                new_security_comment = should_write_comment(
+                    config.disable_security_issue,
+                    len(diff.new_alerts) > 0,
+                    update_old_security_comment,
+                )
+                if not new_security_comment:
+                    log.debug("Security issue comment disabled, or no alerts and none to update")
+
                 # FIXME: diff.new_packages is never populated, neither is removed_packages
-                if (len(diff.new_packages) == 0) or config.disable_overview:
-                    if not update_old_overview_comment:
-                        new_overview_comment = False
-                        log.debug("No new/removed packages or Dependency Overview comment disabled")
-                    else:
-                        log.debug("Updated overview comment with no dependencies")
+                new_overview_comment = should_write_comment(
+                    config.disable_overview,
+                    len(diff.new_packages) > 0,
+                    update_old_overview_comment,
+                )
+                if not new_overview_comment:
+                    log.debug("Dependency Overview comment disabled, or no packages and none to update")
                 
                 log.debug(f"Adding comments for {config.scm}")
                 scm.add_socket_comments(

--- a/tests/unit/test_pr_comment_rendering.py
+++ b/tests/unit/test_pr_comment_rendering.py
@@ -1,0 +1,304 @@
+"""Regression tests for CE-381: orphaned tags and empty tables in PR comments.
+
+A whitespace-only line closes a CommonMark HTML block. When one lands inside the
+alerts table the closing tags after it stop being markup, and since they are
+indented four or more spaces GitHub renders them as a literal code block reading
+`</blockquote></details>`. Separately, a comment whose alerts were all resolved or
+ignored used to keep its "Caution" banner above a table with no rows.
+"""
+
+from dataclasses import dataclass
+
+from socketsecurity.core.classes import Comment, Diff, Issue
+from socketsecurity.core.messages import Messages
+from socketsecurity.core.scm_comments import Comments
+
+
+@dataclass
+class _FakeConfig:
+    disable_ignore: bool = False
+    scm: str = "github"
+
+
+def _make_alert(**overrides) -> Issue:
+    defaults = dict(
+        pkg_name="lodash",
+        pkg_version="4.17.21",
+        pkg_type="npm",
+        severity="high",
+        title="Known Malware",
+        description="Test description",
+        type="malware",
+        url="https://socket.dev/test",
+        manifests="package.json",
+        props={},
+        key="test-key",
+        purl="pkg:npm/lodash@4.17.21",
+        error=True,
+        warn=False,
+        ignore=False,
+        monitor=False,
+        suggestion="Remove this package",
+        next_step_title="Next steps",
+        emoji="🚨",
+    )
+    defaults.update(overrides)
+    return Issue(**defaults)
+
+
+def _make_diff(alerts: list) -> Diff:
+    diff = Diff()
+    diff.id = "test-scan-id"
+    diff.diff_url = "https://socket.dev/report/abc"
+    diff.new_alerts = alerts
+    return diff
+
+
+def _make_comment(body: str, comment_id: int = 1) -> Comment:
+    return Comment(
+        id=comment_id,
+        body=body,
+        body_list=body.split("\n"),
+        reactions={"+1": 0},
+        user={"login": "test-user", "id": 123},
+    )
+
+
+def assert_html_block_intact(body: str) -> None:
+    """Fails if the body can break out of its HTML block when rendered."""
+    for number, line in enumerate(body.split("\n"), 1):
+        assert line == "" or line.strip(), (
+            f"line {number} is whitespace-only, which closes the HTML block: {line!r}"
+        )
+        indent = len(line) - len(line.lstrip())
+        assert indent < 4, (
+            f"line {number} is indented {indent} spaces and would render as a "
+            f"code block if the HTML block ever closes early: {line!r}"
+        )
+
+
+# --- normalize_comment_html ---
+
+class TestNormalizeCommentHtml:
+    def test_drops_whitespace_only_lines(self):
+        result = Messages.normalize_comment_html("<p>a</p>\n    \n<p>b</p>")
+        assert result == "<p>a</p>\n<p>b</p>"
+
+    def test_preserves_genuinely_empty_separator_lines(self):
+        result = Messages.normalize_comment_html("<!-- marker -->\n\n> text")
+        assert result == "<!-- marker -->\n\n> text"
+
+    def test_caps_indentation_below_code_block_threshold(self):
+        result = Messages.normalize_comment_html("        </details>")
+        assert result == "   </details>"
+
+    def test_preserves_trailing_markdown_line_breaks(self):
+        result = Messages.normalize_comment_html("> **Caution**  ")
+        assert result == "> **Caution**  "
+
+
+# --- inline_html_text ---
+
+class TestInlineHtmlText:
+    def test_collapses_newlines(self):
+        assert Messages.inline_html_text("one\n\ntwo") == "one two"
+
+    def test_handles_none(self):
+        assert Messages.inline_html_text(None) == ""
+
+
+# --- Generated comment bodies ---
+
+class TestSecurityCommentTemplateRendering:
+    def test_security_alert_row_is_render_safe(self):
+        body = Messages.security_comment_template(_make_diff([_make_alert()]), _FakeConfig())
+        assert_html_block_intact(body)
+
+    def test_render_safe_when_ignore_instructions_disabled(self):
+        """The empty ignore block used to leave a whitespace-only line behind."""
+        body = Messages.security_comment_template(
+            _make_diff([_make_alert()]), _FakeConfig(disable_ignore=True)
+        )
+        assert_html_block_intact(body)
+        assert "</blockquote>" in body
+        assert "@SocketSecurity ignore" not in body
+
+    def test_license_row_render_safe_when_ignore_instructions_disabled(self):
+        body = Messages.security_comment_template(
+            _make_diff([_make_alert(type="licenseSpdxDisj", title="LGPL-3.0")]),
+            _FakeConfig(disable_ignore=True),
+        )
+        assert_html_block_intact(body)
+        assert "License Policy Violation" in body
+
+    def test_multiline_alert_text_is_flattened(self):
+        body = Messages.security_comment_template(
+            _make_diff([
+                _make_alert(description="Line one.\n\nLine two.", suggestion="Do this.\nThen that.")
+            ]),
+            _FakeConfig(),
+        )
+        assert_html_block_intact(body)
+        assert "<p><strong>Note:</strong> Line one. Line two.</p>" in body
+        assert "Do this. Then that." in body
+
+    def test_license_finding_text_is_flattened(self):
+        body = Messages.security_comment_template(
+            _make_diff([_make_alert(type="licenseSpdxDisj", title="LGPL-3.0\n\nAND MIT")]),
+            _FakeConfig(),
+        )
+        assert_html_block_intact(body)
+        assert "<li>LGPL-3.0 AND MIT</li>" in body
+
+    def test_alert_markers_are_preserved(self):
+        body = Messages.security_comment_template(_make_diff([_make_alert()]), _FakeConfig())
+        assert "<!-- start-socket-alert-lodash@4.17.21 -->" in body
+        assert "<!-- end-socket-alert-lodash@4.17.21 -->" in body
+
+
+class TestSecurityCommentTemplateWithNoAlerts:
+    def test_no_alerts_omits_the_empty_table(self):
+        body = Messages.security_comment_template(_make_diff([]), _FakeConfig())
+        assert "<table>" not in body
+        assert "Caution" not in body
+        assert "No dependency alerts to report" in body
+
+    def test_no_alerts_keeps_the_comment_discoverable(self):
+        """The marker has to survive so a later commit updates this comment
+        instead of posting a second one."""
+        body = Messages.security_comment_template(_make_diff([]), _FakeConfig())
+        found = Comments.check_for_socket_comments({1: _make_comment(body)})
+        assert "security" in found
+
+    def test_no_alerts_keeps_the_report_link(self):
+        body = Messages.security_comment_template(_make_diff([]), _FakeConfig())
+        assert "[View full report](https://socket.dev/report/abc)" in body
+
+    def test_no_alerts_without_report_url_omits_the_link(self):
+        diff = Diff()
+        diff.id = "test-scan-id"
+        diff.new_alerts = []
+        body = Messages.security_comment_template(diff, _FakeConfig())
+        assert "View full report" not in body
+
+
+# --- Ignore round trip ---
+
+def _security_comment_with(alerts: list, config=None) -> Comment:
+    body = Messages.security_comment_template(_make_diff(alerts), config or _FakeConfig())
+    return _make_comment(body)
+
+
+class TestProcessUpdatedSecurityComment:
+    def _two_alert_comment(self) -> Comment:
+        return _security_comment_with([
+            _make_alert(),
+            _make_alert(pkg_name="express", pkg_version="4.18.2", purl="pkg:npm/express@4.18.2"),
+        ])
+
+    def test_partial_ignore_keeps_remaining_alert_render_safe(self):
+        security = self._two_alert_comment()
+        ignore = _make_comment("SocketSecurity ignore lodash@4.17.21", comment_id=2)
+        comments = {"security": security, "ignore": [ignore]}
+
+        new_body = Comments.process_security_comment(security, comments)
+
+        assert_html_block_intact(new_body)
+        assert "start-socket-alert-express@4.18.2" in new_body
+        assert "start-socket-alert-lodash@4.17.21" not in new_body
+
+    def test_ignore_all_collapses_to_the_no_alerts_body(self):
+        security = self._two_alert_comment()
+        ignore = _make_comment("SocketSecurity ignore-all", comment_id=2)
+        comments = {"security": security, "ignore": [ignore]}
+
+        new_body = Comments.process_security_comment(security, comments)
+
+        assert "<table>" not in new_body
+        assert "No dependency alerts to report" in new_body
+        assert "[View full report](https://socket.dev/report/abc)" in new_body
+
+    def test_ignoring_every_alert_individually_collapses_too(self):
+        security = self._two_alert_comment()
+        comments = {
+            "security": security,
+            "ignore": [
+                _make_comment("SocketSecurity ignore lodash@4.17.21", comment_id=2),
+                _make_comment("SocketSecurity ignore express@4.18.2", comment_id=3),
+            ],
+        }
+
+        new_body = Comments.process_security_comment(security, comments)
+
+        assert "No dependency alerts to report" in new_body
+
+    def test_no_ignore_commands_leaves_alerts_in_place(self):
+        security = self._two_alert_comment()
+        comments = {"security": security, "ignore": []}
+
+        new_body = Comments.process_security_comment(security, comments)
+
+        assert "start-socket-alert-lodash@4.17.21" in new_body
+        assert "start-socket-alert-express@4.18.2" in new_body
+
+    def test_collapsed_body_is_stable_when_reprocessed(self):
+        security = self._two_alert_comment()
+        ignore = _make_comment("SocketSecurity ignore-all", comment_id=2)
+        comments = {"security": security, "ignore": [ignore]}
+
+        first = Comments.process_security_comment(security, comments)
+        comments["security"] = _make_comment(first)
+        second = Comments.process_security_comment(comments["security"], comments)
+
+        assert first == second
+
+
+LEGACY_COMMENT = """<!-- socket-security-comment-actions -->
+
+<!-- start-socket-alerts-table -->
+|Alert|Package|Introduced by|Manifest File|CI|
+|:---|:---|:---|:---|:---|
+|Known Malware|[npm/lodash@4.17.21](https://socket.dev/x)|lodash|package.json|:no_entry_sign:|
+|Known Malware|[npm/express@4.18.2](https://socket.dev/y)|express|package.json|:no_entry_sign:|
+<!-- end-socket-alerts-table -->
+
+[View full report](https://socket.dev/report/legacy?action=error%2Cwarn)
+"""
+
+
+class TestProcessOriginalSecurityComment:
+    def test_partial_ignore_keeps_remaining_row(self):
+        security = _make_comment(LEGACY_COMMENT)
+        comments = {
+            "security": security,
+            "ignore": [_make_comment("SocketSecurity ignore npm/lodash@4.17.21", comment_id=2)],
+        }
+
+        new_body = Comments.process_security_comment(security, comments)
+
+        assert "npm/express@4.18.2" in new_body
+        assert "npm/lodash@4.17.21" not in new_body
+
+    def test_ignore_all_collapses_to_the_no_alerts_body(self):
+        security = _make_comment(LEGACY_COMMENT)
+        comments = {
+            "security": security,
+            "ignore": [_make_comment("SocketSecurity ignore-all", comment_id=2)],
+        }
+
+        new_body = Comments.process_security_comment(security, comments)
+
+        assert "|Alert|Package|" not in new_body
+        assert "No dependency alerts to report" in new_body
+        assert "[View full report](https://socket.dev/report/legacy)" in new_body
+
+
+class TestExtractReportUrl:
+    def test_strips_the_action_filter(self):
+        url = Comments.extract_report_url(
+            "[View full report](https://socket.dev/report/abc?action=error%2Cwarn)"
+        )
+        assert url == "https://socket.dev/report/abc"
+
+    def test_returns_empty_when_absent(self):
+        assert Comments.extract_report_url("no link here") == ""

--- a/tests/unit/test_socketcli.py
+++ b/tests/unit/test_socketcli.py
@@ -4,7 +4,7 @@ import pytest
 
 from socketsecurity.core.classes import Diff, Package
 from socketsecurity import socketcli
-from socketsecurity.socketcli import build_license_artifact_payload
+from socketsecurity.socketcli import build_license_artifact_payload, should_write_comment
 
 
 # ---------------------------------------------------------------------------
@@ -228,3 +228,46 @@ def test_build_license_artifact_payload_fossa_format_serializes_dependencies():
     assert payload["deepDependencies"] == []
     assert payload["copyrightsByLicense"] == {}
     assert payload["licenses"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Comment write decision.
+#
+# --disable-security-issue used to be checked only after the "is there already
+# a comment" test, so it suppressed the first post on a pull request and then
+# updated that comment with the full alerts table on every later run.
+# ---------------------------------------------------------------------------
+
+
+class TestShouldWriteComment:
+    def test_disabled_never_writes_even_when_a_comment_exists(self):
+        assert should_write_comment(
+            disabled=True, has_findings=True, update_existing=True
+        ) is False
+
+    def test_disabled_never_writes_with_no_existing_comment(self):
+        assert should_write_comment(
+            disabled=True, has_findings=True, update_existing=False
+        ) is False
+
+    def test_disabled_wins_over_findings(self):
+        """The flag is not conditional on there being nothing to report."""
+        assert should_write_comment(
+            disabled=True, has_findings=False, update_existing=True
+        ) is False
+
+    def test_findings_are_written(self):
+        assert should_write_comment(
+            disabled=False, has_findings=True, update_existing=False
+        ) is True
+
+    def test_no_findings_refreshes_an_existing_comment(self):
+        """So a resolved alerts table gets cleared rather than left stale."""
+        assert should_write_comment(
+            disabled=False, has_findings=False, update_existing=True
+        ) is True
+
+    def test_no_findings_does_not_open_a_new_comment(self):
+        assert should_write_comment(
+            disabled=False, has_findings=False, update_existing=False
+        ) is False

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "socketsecurity"
-version = "2.6.12"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

Two fixes to the pull request comment the CLI posts:

1. **Rendering artifacts.** Security comments could render orphaned `</blockquote></details>` tags as a literal code block, and could leave the "Caution" banner sitting above an alerts table with no rows. A whitespace-only line closes a CommonMark HTML block; optional sections that rendered as empty left one behind inside the table, and because the closing tags after it are indented four or more spaces they were rendered as an indented code block rather than markup. The empty table appeared separately, when a comment's alerts were all resolved by a later commit or ignored by comment.
2. **Comment disable flags.** `--disable-security-issue` and `--disable-overview` were checked only after testing whether a comment of that type already existed, so they suppressed the first post and then updated that comment on every later run.

## Changes

- Generated comment markup no longer contains blank lines and stays under the indentation that starts a code block.
- Alert descriptions, suggestions and license findings are collapsed onto a single line, so multi-line API text cannot break the table either.
- When no alerts are left to report, the comment body is replaced with a short confirmation instead of an empty table. The comment marker is preserved, so a commit that reintroduces an alert updates the same comment rather than posting a second one.
- `@SocketSecurity ignore-all` now applies to comments in the pre-2.0.55 Markdown table format. The check was made once per ignore command, and an ignore-all comment produces none, so no rows were removed.
- The disable flags now mean the CLI does not manage that comment at all. An existing comment is left untouched rather than rewritten, since a body claiming no alerts would be inaccurate when reporting is merely switched off.

Bumps to 2.7.0 rather than a patch, since the disable flags change behavior.

## Testing

- `tests/unit/test_pr_comment_rendering.py` covers both rendering artifacts, the ignore round trips, and the collapsed body. `tests/unit/test_socketcli.py` covers the comment write decision, which previously had no harness.
- Every generated body was rendered through GitHub's `/markdown` API to confirm the tags are gone; 423 unit and 87 core tests pass.

Fixes CE-381
Fixes CE-427
