### PR TITLE
Make tar_hash required for reachability analysis

### DIFF
--- a/socketsecurity/core/tools/reachability.py
+++ b/socketsecurity/core/tools/reachability.py
@@ -77,7 +77,7 @@ class ReachabilityAnalyzer:
         self,
         org_slug: str,
         target_directory: str,
-        tar_hash: Optional[str] = None,
+        tar_hash: str,
         output_path: str = ".socket.facts.json",
         timeout: Optional[str] = None,
         memory_limit: Optional[str] = None,
@@ -151,9 +151,7 @@ class ReachabilityAnalyzer:
         
         # Add conditional arguments. timeout/memory_limit are forwarded verbatim; coana owns
         # unit parsing/validation (e.g. '90s', '8GB'). We coerce to str only for subprocess
-        # safety — config-file values can arrive as ints via argparse set_defaults — and use
-        # `is not None` (not truthiness) so an explicit empty string still reaches coana and
-        # triggers coana's own error, rather than being silently dropped.
+        # safety — config-file values can arrive as ints via argparse set_defaults.
         if timeout is not None:
             coana_args.extend(["--analysis-timeout", str(timeout)])
 
@@ -170,9 +168,7 @@ class ReachabilityAnalyzer:
         if detailed_analysis_log_file:
             coana_args.append("--print-analysis-log-file")
 
-        # KEY POINT: Only add manifest tar hash if we have one
-        if tar_hash:
-            coana_args.extend(["--run-without-docker", "--manifests-tar-hash", tar_hash])
+        coana_args.extend(["--run-without-docker", "--manifests-tar-hash", tar_hash])
         
         if ecosystems:
             coana_args.extend(["--purl-types"] + ecosystems)

--- a/socketsecurity/socketcli.py
+++ b/socketsecurity/socketcli.py
@@ -391,14 +391,11 @@ def main_code():
 
             # Find manifest files in scan paths (excluding .socket.facts.json to avoid circular dependency)
             log.info("Finding manifest files for reachability analysis...")
-            manifest_files = []
-
-            # Always find all manifest files for the tar hash upload
-            for scan_path in scan_paths:
-                scan_manifests = core.find_files(scan_path)
-                # Filter out .socket.facts.json files from manifest upload
-                scan_manifests = [f for f in scan_manifests if not f.endswith('.socket.facts.json')]
-                manifest_files.extend(scan_manifests)
+            manifest_files = [
+                # Always find all manifest files for the tar hash upload
+                f for scan_path in scan_paths for f in core.find_files(scan_path)
+                if not f.endswith('.socket.facts.json')
+            ]
             
             if not manifest_files:
                 log.warning("No manifest files found for reachability analysis")
@@ -410,6 +407,7 @@ def main_code():
                 try:
                     # Get org_slug early (we'll need it)
                     org_slug = core.config.org_slug
+                    assert org_slug
                     
                     # Upload manifest files
                     tar_hash = sdk.uploadmanifests.upload_manifest_files(

--- a/tests/unit/test_reachability.py
+++ b/tests/unit/test_reachability.py
@@ -44,7 +44,7 @@ def _spawn_mock(analyzer, mocker, returncode=0, **kwargs):
     completed.returncode = returncode
     run_mock = mocker.patch.object(reachability.subprocess, "run", return_value=completed)
 
-    analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".", **kwargs)
+    analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".", tar_hash="tar-hash-abc123", **kwargs)
     return run_mock
 
 
@@ -246,7 +246,7 @@ def _capture_spawns(analyzer, mocker, npx_behavior, **kwargs):
         return m
 
     mocker.patch.object(reachability.subprocess, "run", side_effect=fake_run)
-    analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".", **kwargs)
+    analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".", tar_hash="tar-hash-abc123", **kwargs)
     return calls
 
 
@@ -285,7 +285,7 @@ def test_no_fallback_on_ambiguous_exit_code(analyzer, mocker):
 
     mocker.patch.object(reachability.subprocess, "run", side_effect=fake_run)
     with pytest.raises(Exception):
-        analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".")
+        analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".", tar_hash="tar-hash-abc123")
     assert calls[0][0] == "npx"
     assert all(c[:2] != ["npm", "install"] for c in calls)
 
@@ -313,7 +313,7 @@ def test_disable_fallback_propagates_npx_failure(analyzer, mocker, monkeypatch):
 
     mocker.patch.object(reachability.subprocess, "run", side_effect=fake_run)
     with pytest.raises(Exception):
-        analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".")
+        analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".", tar_hash="tar-hash-abc123")
     assert all(c[:2] != ["npm", "install"] for c in calls)
 
 
@@ -340,7 +340,7 @@ def test_launcher_npx_propagates_npx_failure(analyzer, mocker, monkeypatch):
 
     mocker.patch.object(reachability.subprocess, "run", side_effect=fake_run)
     with pytest.raises(Exception):
-        analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".")
+        analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".", tar_hash="tar-hash-abc123")
     assert calls[0][0] == "npx"
     assert all(c[:2] != ["npm", "install"] for c in calls)
 
@@ -385,8 +385,8 @@ def test_fallback_installs_once_per_version(analyzer, mocker):
         return m
 
     mocker.patch.object(reachability.subprocess, "run", side_effect=fake_run)
-    analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".")
-    analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".")
+    analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".", tar_hash="tar-hash-abc123")
+    analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".", tar_hash="tar-hash-abc123")
 
     npm_installs = [c for c in calls if c[:2] == ["npm", "install"]]
     assert len(npm_installs) == 1  # installed once, reused on the second fallback
@@ -415,7 +415,7 @@ def test_fallback_node_missing_raises_clear_error(analyzer, mocker):
 
     mocker.patch.object(reachability.subprocess, "run", side_effect=fake_run)
     with pytest.raises(Exception, match="node"):
-        analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".")
+        analyzer.run_reachability_analysis(org_slug="my-org", target_directory=".", tar_hash="tar-hash-abc123")
 
 
 def test_build_coana_node_cmd_js_vs_binary():


### PR DESCRIPTION
`run_reachability_analysis()` always receives a manifest tar hash from its only caller, so `tar_hash` no longer defaults to `None`.

- Drop the `Optional[str] = None` default in favour of a required `str`.
- Drop the conditional that skipped `--run-without-docker` / `--manifests-tar-hash` when no hash was present; those flags are now always passed.
- Simplify manifest discovery in `socketcli.py` into a comprehension.
- Pass `tar_hash` at the test call sites.

No test assertions changed: nothing in the suite covered `--manifests-tar-hash` or `--run-without-docker`, so the removed branch was untested in either direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract tightening on an internal API with a single caller; behavior for the supported CLI flow is unchanged aside from always forwarding manifest hash flags to Coana.
> 
> **Overview**
> **Reachability analysis now always requires a manifest upload tar hash** and always passes it to Coana via `--run-without-docker` and `--manifests-tar-hash`.
> 
> `run_reachability_analysis()` takes a required `tar_hash: str` instead of optional `None`, and the branch that omitted those flags when no hash was present is removed. That matches the CLI path, which only invokes the analyzer after `upload_manifest_files` succeeds.
> 
> In `socketcli.py`, manifest discovery is collapsed into one comprehension (still excluding `.socket.facts.json`), and `assert org_slug` is added before upload. Unit tests pass a fixed `tar_hash` at every call site; assertions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b7e87a8d5c37ef0c04cd27e3612ff94d20703c0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->