### PR TITLE
Apply ruff autofixes and add a ruff CI job

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -67,6 +67,26 @@ jobs:
           uv export --no-hashes --no-emit-project --format requirements-txt > /tmp/req-audit.txt
           uvx pip-audit --strict --progress-spinner off --disable-pip --no-deps -r /tmp/req-audit.txt
 
+  ruff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: 🐍 setup python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: 🛠️ install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+          uv sync --extra dev
+      - name: 🧹 run ruff
+        run: uv run ruff check
+
   unsupported-python-install:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/socketsecurity/config.py
+++ b/socketsecurity/config.py
@@ -1,12 +1,14 @@
 import argparse
+import json
 import logging
 import os
+import tomllib
 from dataclasses import asdict, dataclass, field
 from typing import List, Optional
-from socketsecurity import __version__
+
 from socketdev import INTEGRATION_TYPES, IntegrationType
-import json
-import tomllib
+
+from socketsecurity import __version__
 
 
 def get_plugin_config_from_env(prefix: str) -> dict:

--- a/socketsecurity/core/cli_client.py
+++ b/socketsecurity/core/cli_client.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Union
 import requests
 
 from socketsecurity import USER_AGENT
+
 from .exceptions import APIFailure
 from .socket_config import SocketConfig
 

--- a/socketsecurity/core/helper/__init__.py
+++ b/socketsecurity/core/helper/__init__.py
@@ -1,7 +1,8 @@
+import string
+
 import markdown
 from bs4 import BeautifulSoup, Tag
 from bs4.element import NavigableString
-import string
 
 
 class Helper:

--- a/socketsecurity/core/helper/socket_facts_loader.py
+++ b/socketsecurity/core/helper/socket_facts_loader.py
@@ -2,9 +2,9 @@
 
 import json
 import logging
-from pathlib import Path
-from typing import Dict, Any, Optional, List
 from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ def load_socket_facts(file_path: str = ".socket.facts.json") -> Optional[Dict[st
             return None
         
         if 'components' not in data:
-            logger.warning(f"Socket facts file missing 'components' key")
+            logger.warning("Socket facts file missing 'components' key")
         
         return data
     

--- a/socketsecurity/core/lazy_file_loader.py
+++ b/socketsecurity/core/lazy_file_loader.py
@@ -2,9 +2,7 @@
 Lazy file loading utilities for efficient manifest file processing.
 """
 import logging
-from typing import List, Tuple, Union, BinaryIO
-from io import BytesIO
-import os
+from typing import List, Tuple
 
 log = logging.getLogger("socketdev")
 

--- a/socketsecurity/core/messages.py
+++ b/socketsecurity/core/messages.py
@@ -5,6 +5,7 @@ import re
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
+
 from mdutils import MdUtils
 from prettytable import PrettyTable
 

--- a/socketsecurity/core/resource_utils.py
+++ b/socketsecurity/core/resource_utils.py
@@ -2,7 +2,6 @@
 System resource utilities for the Socket Security CLI.
 """
 import logging
-import sys
 
 # The resource module is only available on Unix-like systems
 resource_available = False

--- a/socketsecurity/core/scm/client.py
+++ b/socketsecurity/core/scm/client.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 from typing import Dict
 
 from socketsecurity import USER_AGENT
+
 from ..cli_client import CliClient
 
 

--- a/socketsecurity/core/scm/gitlab.py
+++ b/socketsecurity/core/scm/gitlab.py
@@ -2,9 +2,10 @@ import json
 import os
 import sys
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional
 
 import requests
+
 from socketsecurity import USER_AGENT
 from socketsecurity.core import log
 from socketsecurity.core.classes import Comment
@@ -140,7 +141,7 @@ class Gitlab:
         except requests.exceptions.HTTPError as e:
             # Check if this is an authentication error (401)
             if e.response and e.response.status_code == 401:
-                log.debug(f"Authentication failed with initial headers, trying fallback method")
+                log.debug("Authentication failed with initial headers, trying fallback method")
                 
                 # Determine the fallback headers
                 original_headers = kwargs.get('headers', self.config.headers)
@@ -153,7 +154,7 @@ class Gitlab:
             
             # Re-raise the original exception if it's not an auth error or fallback failed
             raise
-        except Exception as e:
+        except Exception:
             # Handle other types of exceptions that don't have response attribute
             raise
 

--- a/socketsecurity/core/socket_config.py
+++ b/socketsecurity/core/socket_config.py
@@ -1,12 +1,11 @@
-from dataclasses import dataclass, field
-from typing import Dict, Optional
-from urllib.parse import urlparse
-from typing import Set, List
 import os
+from dataclasses import dataclass, field
+from typing import List, Optional, Set
+from urllib.parse import urlparse
 
 from socketdev.core.issues import AllIssues
-from socketsecurity import __version__
 
+from socketsecurity import __version__
 
 default_exclude_dirs = {
     "node_modules", "bower_components", "jspm_packages",   # JS/TS

--- a/socketsecurity/core/tools/reachability.py
+++ b/socketsecurity/core/tools/reachability.py
@@ -1,15 +1,16 @@
-from socketdev import socketdev
-from typing import List, Optional, Dict, Any, Final
 import atexit
+import json
+import logging
 import os
+import pathlib
 import platform
 import shutil
 import subprocess
-import json
-import pathlib
-import logging
 import sys
 import tempfile
+from typing import Any, Dict, Final, List, Optional
+
+from socketdev import socketdev
 
 from socketsecurity import __version__
 
@@ -258,7 +259,7 @@ class ReachabilityAnalyzer:
             # Extract scan ID from output file
             scan_id = self._extract_scan_id(output_path)
             
-            log.info(f"Reachability analysis completed successfully")
+            log.info("Reachability analysis completed successfully")
             if scan_id:
                 log.info(f"Scan ID: {scan_id}")
             

--- a/socketsecurity/output.py
+++ b/socketsecurity/output.py
@@ -2,18 +2,21 @@ import json
 import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
-from .core.messages import Messages
-from .core.classes import Diff, Issue
-from .config import CliConfig
-from .fossa_compat import build_fossa_report_payload
-from socketsecurity.plugins.manager import PluginManager
+
+from socketdev import socketdev
+
 from socketsecurity.core.alert_selection import (
     clone_diff_with_selected_alerts,
     filter_alerts_by_reachability,
     load_components_with_alerts,
     select_diff_alerts,
 )
-from socketdev import socketdev
+from socketsecurity.plugins.manager import PluginManager
+
+from .config import CliConfig
+from .core.classes import Diff, Issue
+from .core.messages import Messages
+from .fossa_compat import build_fossa_report_payload
 
 
 class OutputHandler:

--- a/socketsecurity/plugins/formatters/slack.py
+++ b/socketsecurity/plugins/formatters/slack.py
@@ -1,8 +1,8 @@
 """Slack formatter for Socket Facts (reachability analysis) data."""
 
 import logging
-from typing import Dict, Any, List
 from collections import defaultdict
+from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 

--- a/socketsecurity/plugins/jira.py
+++ b/socketsecurity/plugins/jira.py
@@ -1,9 +1,12 @@
-from .base import Plugin
-import requests
 import base64
-from socketsecurity.core.classes import Diff
+
+import requests
+
 from socketsecurity.config import CliConfig
 from socketsecurity.core import log
+from socketsecurity.core.classes import Diff
+
+from .base import Plugin
 
 
 class JiraPlugin(Plugin):

--- a/socketsecurity/plugins/manager.py
+++ b/socketsecurity/plugins/manager.py
@@ -1,4 +1,4 @@
-from . import jira, webhook, slack, teams
+from . import jira, slack, teams, webhook
 
 PLUGIN_CLASSES = {
     "jira": jira.JiraPlugin,

--- a/socketsecurity/plugins/slack.py
+++ b/socketsecurity/plugins/slack.py
@@ -1,21 +1,24 @@
 import logging
 import os
+
 import requests
+
 from socketsecurity.config import CliConfig
-from .base import Plugin
-from socketsecurity.core.classes import Diff
-from socketsecurity.core.messages import Messages
 from socketsecurity.core.alert_selection import (
     clone_diff_with_selected_alerts,
     filter_alerts_by_reachability,
     select_diff_alerts,
 )
+from socketsecurity.core.classes import Diff
 from socketsecurity.core.helper.socket_facts_loader import (
-    load_socket_facts,
+    convert_to_alerts,
     get_components_with_vulnerabilities,
-    convert_to_alerts
+    load_socket_facts,
 )
+from socketsecurity.core.messages import Messages
 from socketsecurity.plugins.formatters.slack import format_socket_facts_for_slack
+
+from .base import Plugin
 
 logger = logging.getLogger(__name__)
 

--- a/socketsecurity/plugins/teams.py
+++ b/socketsecurity/plugins/teams.py
@@ -1,5 +1,7 @@
-from .base import Plugin
 import requests
+
+from .base import Plugin
+
 
 class TeamsPlugin(Plugin):
     def send(self, message, level):

--- a/socketsecurity/plugins/webhook.py
+++ b/socketsecurity/plugins/webhook.py
@@ -1,5 +1,7 @@
-from .base import Plugin
 import requests
+
+from .base import Plugin
+
 
 class WebhookPlugin(Plugin):
     def send(self, message, level):

--- a/tests/core/test_diff_alerts.py
+++ b/tests/core/test_diff_alerts.py
@@ -1,4 +1,3 @@
-import pytest
 from socketsecurity.core import Core
 from socketsecurity.core.classes import Issue
 

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -1,4 +1,5 @@
 import pytest
+
 from socketsecurity.config import CliConfig
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,9 +1,12 @@
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 import requests
+
 from socketsecurity.core.cli_client import CliClient
-from socketsecurity.core.socket_config import SocketConfig
 from socketsecurity.core.exceptions import APIFailure
+from socketsecurity.core.socket_config import SocketConfig
+
 
 @pytest.fixture
 def config():
@@ -100,14 +103,14 @@ def test_request_ssl_verification(client):
         client.request("test/path")
 
         args, kwargs = mock_request.call_args
-        assert kwargs['verify'] == True  # Default is True
+        assert kwargs['verify']  # Default is True
 
         # Test with SSL verification disabled
         client.config.allow_unverified_ssl = True
         client.request("test/path")
 
         args, kwargs = mock_request.call_args
-        assert kwargs['verify'] == False
+        assert not kwargs['verify']
 
 def test_request_with_payload(client):
     """Test request with payload data"""
@@ -154,7 +157,6 @@ def test_post_telemetry_events_sends_individually(client):
 
 def test_post_telemetry_events_continues_on_failure(client):
     """Test that a failed event does not prevent subsequent events from being sent"""
-    import json
 
     events = [
         {"event_kind": "user-action", "artifact_purl": "pkg:npm/foo@1.0.0"},

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,9 +1,11 @@
-from pathlib import Path
-import pytest
-from unittest.mock import patch
 import tomllib
-from socketsecurity.core.socket_config import SocketConfig
+from pathlib import Path
+
+import pytest
+
 from socketsecurity.config import CliConfig
+from socketsecurity.core.socket_config import SocketConfig
+
 
 def test_config_default_values():
     """Test that config initializes with correct default values"""

--- a/tests/unit/test_disable_ignore.py
+++ b/tests/unit/test_disable_ignore.py
@@ -1,13 +1,11 @@
 """Tests for the --disable-ignore flag."""
 
-import pytest
 from dataclasses import dataclass
 
 from socketsecurity.config import CliConfig
 from socketsecurity.core.classes import Comment, Diff, Issue
 from socketsecurity.core.messages import Messages
 from socketsecurity.core.scm_comments import Comments
-
 
 # --- CLI flag parsing tests ---
 

--- a/tests/unit/test_gitlab_auth.py
+++ b/tests/unit/test_gitlab_auth.py
@@ -1,7 +1,8 @@
 """Tests for GitLab authentication patterns"""
 import os
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 from socketsecurity import USER_AGENT
 from socketsecurity.core.scm.gitlab import GitlabConfig

--- a/tests/unit/test_gitlab_auth_fallback.py
+++ b/tests/unit/test_gitlab_auth_fallback.py
@@ -1,9 +1,10 @@
 """Integration test demonstrating GitLab authentication fallback"""
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from socketsecurity.core.scm.gitlab import Gitlab, GitlabConfig
+from socketsecurity.core.scm.gitlab import Gitlab
 from socketsecurity.socketcli import CliClient
 
 
@@ -37,7 +38,7 @@ class TestGitlabAuthFallback:
         gitlab = Gitlab(client=mock_client)
         
         # This should trigger the fallback mechanism
-        result = gitlab.get_comments_for_pr()
+        gitlab.get_comments_for_pr()
         
         # Verify two requests were made
         assert mock_client.request.call_count == 2
@@ -79,7 +80,7 @@ class TestGitlabAuthFallback:
         gitlab = Gitlab(client=mock_client)
         
         # This should trigger the fallback mechanism
-        result = gitlab.get_comments_for_pr()
+        gitlab.get_comments_for_pr()
         
         # Verify two requests were made
         assert mock_client.request.call_count == 2
@@ -140,7 +141,7 @@ class TestGitlabAuthFallback:
         gitlab = Gitlab(client=mock_client)
         
         # This should succeed on first try
-        result = gitlab.get_comments_for_pr()
+        gitlab.get_comments_for_pr()
         
         # Verify only one request was made
         assert mock_client.request.call_count == 1

--- a/tests/unit/test_gitlab_commit_status.py
+++ b/tests/unit/test_gitlab_commit_status.py
@@ -1,7 +1,5 @@
 """Tests for GitLab commit status integration"""
-import os
-import pytest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import MagicMock, patch
 
 from socketsecurity.core.scm.gitlab import Gitlab, GitlabConfig
 

--- a/tests/unit/test_gitlab_format.py
+++ b/tests/unit/test_gitlab_format.py
@@ -1,8 +1,7 @@
 import re
 
-import pytest
-from socketsecurity.core.messages import Messages
 from socketsecurity.core.classes import Diff, Issue
+from socketsecurity.core.messages import Messages
 
 
 class TestGitLabFormat:

--- a/tests/unit/test_include_dirs.py
+++ b/tests/unit/test_include_dirs.py
@@ -6,8 +6,6 @@ normally-excluded directory (e.g. build) lets Core.find_files discover manifests
 import types
 from unittest.mock import MagicMock
 
-import pytest
-
 from socketsecurity.config import CliConfig
 from socketsecurity.core import Core
 from socketsecurity.core.socket_config import (

--- a/tests/unit/test_socketcli.py
+++ b/tests/unit/test_socketcli.py
@@ -2,10 +2,12 @@ import sys
 
 import pytest
 
-from socketsecurity.core.classes import Diff, Package
 from socketsecurity import socketcli
-from socketsecurity.socketcli import build_license_artifact_payload, should_write_comment
-
+from socketsecurity.core.classes import Diff, Package
+from socketsecurity.socketcli import (
+    build_license_artifact_payload,
+    should_write_comment,
+)
 
 # ---------------------------------------------------------------------------
 # Exit-code-on-api-error (flag-only, non-breaking for 2.3.x).


### PR DESCRIPTION
Runs `uv run ruff check --fix --unsafe-fixes` over the tree and wires ruff into CI so it stays clean.

## Changes

- **Ruff autofixes** across 29 files: import sorting and regrouping (isort), removal of unused imports, dropped `f` prefixes on strings with no placeholders, dropped unused bindings, and `== True`/`== False` assertions simplified to truthiness checks.
- **New `ruff` job** in `.github/workflows/python-tests.yml`, mirroring the checkout and Python setup from `python-tests`. It installs the `dev` extra rather than `test`, since that is where the ruff pin lives.

## Notes for review

The `ruff` job isn't required to pass, so it only buys visibility for now.

## Verification

`uv run ruff check` passes and the suite is green — 423 passed, 2 skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Style and import-only edits plus a non-blocking CI lint job; no changes to auth, API contracts, or core scan logic.
> 
> **Overview**
> Adds a dedicated **`ruff`** GitHub Actions job that checks out the repo, installs deps with `uv sync --extra dev`, and runs **`uv run ruff check`** so lint stays enforced in CI (alongside existing unit tests and pip-audit).
> 
> The rest of the PR is **mechanical ruff cleanup** across the library and tests: **isort-style import ordering**, removal of **unused imports** (e.g. in `lazy_file_loader`, `resource_utils`, several test modules), **dropping pointless f-strings** in log messages, tightening **bare `except`** handlers, and small test tweaks (**truthiness assertions**, dropping unused `result` bindings). No intentional behavior changes beyond what those lint rules require.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d25ca16e27d52ddf4d5d804a6879b4729747fe4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->