### PR TITLE
Install the pinned reachability engine in the Docker image

### DIFF
--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Build the requested version from its own tag. The image installs
+          # socketsecurity==inputs.version from PyPI, and the Dockerfile reads the pinned
+          # @coana-tech/cli version out of the checked-out source, so building from the
+          # default branch would pair an old wheel with a newer build recipe and pin.
+          ref: v${{ inputs.version }}
           persist-credentials: false
 
       - name: Check if version exists in PyPI

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,6 +12,7 @@ on:
       - "tests/core/**/*.py"
       - "pyproject.toml"
       - "uv.lock"
+      - "Dockerfile"
       - ".github/workflows/python-tests.yml"
   pull_request:
     paths:
@@ -20,6 +21,7 @@ on:
       - "tests/core/**/*.py"
       - "pyproject.toml"
       - "uv.lock"
+      - "Dockerfile"
       - ".github/workflows/python-tests.yml"
   workflow_dispatch:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.7.2
+
+### Fixed: the image now installs the pinned reachability engine
+
+- The Docker image installed `@coana-tech/cli` unpinned while the CLI asks npx for the
+  version in `DEFAULT_COANA_CLI_VERSION`. npx reuses the image's global install only when
+  the versions match, so once they diverged every scan downloaded the engine again. The
+  Dockerfile now reads the pinned version out of the source, keeping the image and the
+  runtime aligned without a second place to bump.
+- Marking a release stable now builds that version from its own tag instead of the default
+  branch, so an older release is rebuilt with its own pin and build recipe.
+
 ## 2.7.1
 
 ### Changed: bump pinned @coana-tech/cli to 15.10.36

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,12 +74,29 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
         pypy3 --version; \
     fi
 
-# Install additional tools
-RUN npm install @coana-tech/cli socket -g && \
-    gem install bundler && \
+# Install Ruby bundler and the Rust toolchain
+RUN gem install bundler && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
     . ~/.cargo/env && \
     rustup component add rustfmt clippy
+
+# Install the reachability engine at exactly the version the CLI will ask for.
+# The launcher runs `npx @coana-tech/cli@<DEFAULT_COANA_CLI_VERSION>`, and npx reuses this
+# global install only when the versions match; on a mismatch it downloads the engine again
+# on every scan. Reading the version out of reachability.py keeps the image and the runtime
+# aligned by construction, so the pin stays bumped in exactly one place.
+# reachability.py is copied on its own so bumping the pin rebuilds only this layer rather
+# than the toolchain layer above it.
+COPY socketsecurity/core/tools/reachability.py /tmp/coana-pin/reachability.py
+RUN COANA_CLI_VERSION="$(sed -n 's/^DEFAULT_COANA_CLI_VERSION[^"]*"\([^"]*\)".*/\1/p' \
+        /tmp/coana-pin/reachability.py)" && \
+    if [ -z "$COANA_CLI_VERSION" ]; then \
+        echo "Could not read DEFAULT_COANA_CLI_VERSION from reachability.py" >&2; \
+        exit 1; \
+    fi && \
+    echo "Installing @coana-tech/cli@${COANA_CLI_VERSION} (pinned by reachability.py)" && \
+    npm install "@coana-tech/cli@${COANA_CLI_VERSION}" socket -g && \
+    rm -rf /tmp/coana-pin
 
 # Set environment paths
 ENV PATH="/usr/local/go/bin:/usr/lib/go/bin:/root/.cargo/bin:${PATH}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "socketsecurity"
-version = "2.7.1"
+version = "2.7.2"
 requires-python = ">= 3.11"
 license = {"file" = "LICENSE"}
 dependencies = [

--- a/socketsecurity/__init__.py
+++ b/socketsecurity/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'socket.dev'
-__version__ = '2.7.1'
+__version__ = '2.7.2'
 USER_AGENT = f'SocketPythonCLI/{__version__}'

--- a/tests/unit/test_dockerfile_coana_pin.py
+++ b/tests/unit/test_dockerfile_coana_pin.py
@@ -1,0 +1,50 @@
+"""Guards the image's ``@coana-tech/cli`` install against drifting from the runtime pin.
+
+The launcher asks npx for ``@coana-tech/cli@DEFAULT_COANA_CLI_VERSION``, and npx reuses the
+image's global install only when the versions match; on a mismatch it downloads the engine
+again on every scan. The Dockerfile therefore derives the version from ``reachability.py``
+with a ``sed`` expression instead of repeating it. These tests run that expression against
+the real source, so a reformatted constant or a broken expression fails here rather than
+silently producing a mismatched image.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+from socketsecurity.core.tools.reachability import DEFAULT_COANA_CLI_VERSION
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+REACHABILITY_SOURCE = (
+    REPO_ROOT / "socketsecurity" / "core" / "tools" / "reachability.py"
+)
+
+
+def _dockerfile_sed_expression() -> str:
+    """Return the pin-extraction expression the Dockerfile runs."""
+    match = re.search(
+        r"sed -n '(s/\^DEFAULT_COANA_CLI_VERSION[^']*)'", DOCKERFILE.read_text()
+    )
+    assert match, "Dockerfile no longer extracts DEFAULT_COANA_CLI_VERSION with sed"
+    return match.group(1)
+
+
+def test_dockerfile_expression_extracts_the_pinned_version():
+    extracted = subprocess.run(
+        ["sed", "-n", _dockerfile_sed_expression(), str(REACHABILITY_SOURCE)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert extracted == DEFAULT_COANA_CLI_VERSION
+
+
+def test_dockerfile_never_installs_coana_unpinned():
+    install_lines = [
+        line for line in DOCKERFILE.read_text().splitlines() if "npm install" in line
+    ]
+    assert install_lines, "Dockerfile no longer installs anything with npm"
+    for line in install_lines:
+        if "@coana-tech/cli" in line:
+            assert "@coana-tech/cli@" in line, f"unpinned coana install: {line.strip()}"

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "socketsecurity"
-version = "2.7.1"
+version = "2.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Problem

`Dockerfile` installed `@coana-tech/cli` unpinned, while the launcher asks npx for the version in `DEFAULT_COANA_CLI_VERSION`. npx reuses the image's global install only when the versions match; on a mismatch it downloads the engine again on every scan.

Measured in the published image:

| Requested version | Launcher | npm cache delta |
|---|---|---|
| matches the global install | 3s | 0 MB |
| mismatched | 9s | +119 MB |

The two agreed only because release rebuilds happened to follow the pin bumps. Nothing enforced it, and the failure mode is silent — no error, no test failure, just slower scans and extra egress.

## Change

- The Dockerfile reads the pinned version out of `reachability.py` and installs exactly that, failing the build if the value cannot be read. The pin stays bumped in one place, so the image and the runtime cannot drift.
- The coana install moves out of the toolchain `RUN`. A pin bump now rebuilds a 353 MB layer instead of the 2.3 GB combined layer.
- Marking a release stable builds that version from its own tag. The image installs `socketsecurity==inputs.version` from PyPI, so building from the default branch paired an old wheel with a newer build recipe and pin.
- `tests/unit/test_dockerfile_coana_pin.py` runs the Dockerfile's own extraction expression against the real source and rejects an unpinned install. `Dockerfile` was added to the unit-test path filter so the guard runs on Dockerfile-only changes.

## Verification

- Full image build: baked engine, runtime pin and source all report `15.10.36`; `socketcli --help` and `coana-cli` both work.
- Building against a source file with the constant renamed aborts with `Could not read DEFAULT_COANA_CLI_VERSION from reachability.py` rather than silently installing unpinned.
- After the change npx resolves without downloading — metadata only, no cache growth.
- Both guards fail on their respective mutations and pass when reverted.
- 425 unit tests pass, 2 pre-existing skips. The extraction expression was checked under both BSD and busybox `sed`.

e2e-reachability needs to run here — this changes how the engine is installed, so it is the meaningful gate.

## Not included

`socket` npm is still installed unpinned and the npm cache is still shipped in the image. Both are tracked separately.

---

Refs: CE-431


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the published Docker image installs the reachability engine and how stable releases are built; wrong pinning would affect every containerized scan but is guarded by build failure and new unit tests.
> 
> **Overview**
> Fixes a silent mismatch where the Docker image installed **unpinned** `@coana-tech/cli` while scans invoke `npx` with **`DEFAULT_COANA_CLI_VERSION`** from `reachability.py` — when versions diverged, **npx re-downloaded the engine on every scan** (extra time and egress).
> 
> The **Dockerfile** now copies `reachability.py`, extracts the pin with the same **`sed`** logic used at build time, and **`npm install`s that exact version** (build fails if the constant cannot be read). The Coana install is split into its own layer so pin bumps rebuild a smaller layer instead of the full toolchain step. **Release 2.7.2** bumps package version and changelog accordingly.
> 
> **Mark release stable** (`docker-stable.yml`) now checks out **`v${{ inputs.version }}`** so stable images are built from that tag’s Dockerfile/pin, not `main` paired with an older PyPI wheel.
> 
> CI adds **`tests/unit/test_dockerfile_coana_pin.py`** (sed extraction + no unpinned Coana install) and runs unit tests when **`Dockerfile`** changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21a802db6e3481247476d034495ac8bca8ecc8a2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->